### PR TITLE
docs(installation): rewrite for EULA-based evaluation flow

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -73,30 +73,23 @@ Netzwerk-Visualisierung der Überschneidungen zwischen allen 9 Standards
 
 ---
 
-## Schnellstart
+## Evaluation
 
-=== "Docker (empfohlen)"
+ComplianceOS is proprietary software under a commercial EULA — there is no
+public binary download. Qualified evaluators receive a private deployment
+package and an activation code on request:
 
-    ```bash
-    git clone https://github.com/silentspike/complianceos.git
-    cd complianceos
-    docker compose up -d
-    ```
+1. Open an [Evaluation Request](https://github.com/silentspike/complianceos/issues/new?template=evaluation_request.yml)
+2. We respond within two business days with a scoped evaluation
+3. You deploy the delivered package on your own infrastructure (Linux x86_64,
+   1 GB RAM, no outbound internet required for the core engine)
 
-    Dann öffnen Sie [http://localhost:8001](http://localhost:8001) im Browser.
+Full installation flow: see [Installation](schnellstart/installation.md).
 
-=== "pip"
-
-    ```bash
-    git clone https://github.com/silentspike/complianceos.git
-    cd complianceos
-    python -m venv .venv && source .venv/bin/activate
-    pip install -e ".[ai,docs]"
-    make dev
-    ```
-
-!!! tip "Erster Schritt nach dem Start"
-    Nach dem Start werden Sie auf die **Setup-Seite** weitergeleitet, um Claude AI zu verbinden. Danach legen Sie ein Projekt an und führen Ihren ersten Audit durch. Folgen Sie der Anleitung unter [Erste Schritte](schnellstart/erste-schritte.md).
+!!! tip "Before you request an evaluation"
+    The complete operating manual ([Bedienung](bedienung/dashboard.md)) with
+    24 screenshots and 5 demo videos is publicly available — that is usually
+    enough material for a procurement or security committee to assess fit.
 
 ---
 

--- a/docs/schnellstart/installation.md
+++ b/docs/schnellstart/installation.md
@@ -1,221 +1,101 @@
 # Installation
 
-## Voraussetzungen
-
-### Pflicht
-
-| Anforderung | Minimum | Empfohlen |
-|-------------|---------|-----------|
-| **Docker** + **Docker Compose** | v2.0+ | v2.20+ |
-| **RAM** | 512 MB | 1 GB |
-| **Festplatte** | 1 GB | 5 GB (für Audit-Daten) |
-| **Browser** | Chrome 90+ / Firefox 90+ / Safari 15+ / Edge 90+ | Aktuelle Version |
-| **Betriebssystem** | Linux, macOS, Windows (mit WSL2) | Linux |
-
-### Optional (für KI-Features)
-
-| Anforderung | Beschreibung |
-|-------------|-------------|
-| **Claude Code Subscription** | Für KI-Chat, KI-gestützte Audit-Bewertungen und Policy-Generierung |
-| **Internetzugang** | Nur für KI-Anfragen an die Claude API (alle anderen Daten bleiben lokal) |
-
-!!! info "Ohne Claude AI"
-    ComplianceOS funktioniert auch ohne Claude AI. Die Audit-Engine, Findings, Remediation, Reports und alle anderen Kernfunktionen sind vollständig lokal. Nur der Chat und die KI-gestützten Bewertungen benötigen die Claude-Anbindung.
+ComplianceOS is proprietary software distributed under a [commercial EULA](../../LICENSE).
+There are no public binary downloads, container images or `git clone`able source artifacts.
+Installation happens as part of an evaluation engagement or commercial licensing
+agreement — we deliver the artifact, you deploy it on your own infrastructure.
 
 ---
 
-## Installation mit Docker (empfohlen)
+## How to obtain ComplianceOS
 
-### 1. Repository klonen
+### 1. Request an evaluation
 
-```bash
-git clone https://github.com/silentspike/complianceos.git
-cd complianceos
-```
+Open an [Evaluation Request issue](https://github.com/silentspike/complianceos/issues/new?template=evaluation_request.yml).
+The form captures the information we need to scope a fitting evaluation:
 
-### 2. Container starten
+- Organisation, role and use case
+- Target standards (ISO 27001, ISO 22301, BSI, NIS2, …)
+- Approximate deployment size (single host, VM, on-prem fleet)
+- Acknowledgement of the EULA terms
 
-```bash
-docker compose up -d
-```
+We respond within two business days.
 
-Docker lädt das Image, erstellt die Datenbank und startet den Server. Der erste Start dauert ca. 30-60 Sekunden.
+### 2. Receive the evaluation package
 
-### 3. Im Browser öffnen
+After scoping you receive privately:
 
-Öffnen Sie [http://localhost:8001](http://localhost:8001). Sie werden auf die **Setup-Seite** weitergeleitet, wenn Claude AI noch nicht konfiguriert ist.
+- A signed container image (or a self-contained binary, depending on platform)
+- An activation code tied to your deployment
+- A short onboarding guide that maps to the screens documented under
+  [Bedienung](../bedienung/dashboard.md)
+- Optional: a guided remote walkthrough of the audit workflow
 
-### 4. Health-Check prüfen
+### 3. Deploy on your own infrastructure
 
-```bash
-curl http://localhost:8001/api/health
-```
+ComplianceOS runs entirely on premise. The runtime requirements are modest:
 
-Erwartete Antwort:
+| Requirement | Minimum | Recommended |
+|-------------|---------|-------------|
+| **CPU** | 2 cores | 4 cores |
+| **RAM** | 1 GB | 2 GB |
+| **Disk** | 1 GB | 5 GB (for audit data + reports) |
+| **OS** | Linux x86_64 | Linux x86_64 |
+| **Browser (clients)** | Chrome 90+ / Firefox 90+ / Safari 15+ / Edge 90+ | latest stable |
 
-```json
-{
-  "status": "healthy",
-  "version": "1.0.0",
-  "db": true,
-  "knowledge": true,
-  "claude_sdk": true,
-  "disk_free_mb": 43613
-}
-```
+No outbound internet connectivity is required for the core audit engine —
+findings, reports, policies and remediation tracking all run locally.
 
-!!! tip "Health-Check Felder"
-    - `db`: Datenbankverbindung funktioniert
-    - `knowledge`: Wissensbasis (135 Controls, 9 Standards) geladen
-    - `claude_sdk`: Claude AI SDK verfügbar (optional)
-    - `disk_free_mb`: Freier Speicher in MB
+### 4. Optional: enable AI features (BYOK)
 
----
-
-## Installation mit pip
-
-Für Entwickler oder Umgebungen ohne Docker:
-
-### 1. Repository klonen
-
-```bash
-git clone https://github.com/silentspike/complianceos.git
-cd complianceos
-```
-
-### 2. Virtual Environment erstellen
-
-```bash
-python -m venv .venv
-source .venv/bin/activate  # Linux/macOS
-# .venv\Scripts\activate   # Windows
-```
-
-### 3. Abhängigkeiten installieren
-
-```bash
-# Basis-Installation
-pip install -e .
-
-# Mit KI-Features
-pip install -e ".[ai]"
-
-# Mit Dokumenten-Parser (PDF, DOCX, XLSX)
-pip install -e ".[docs]"
-
-# Alles zusammen
-pip install -e ".[ai,docs]"
-```
-
-### 4. Server starten
-
-```bash
-make dev
-# oder direkt:
-python -m uvicorn app.main:app --host 0.0.0.0 --port 8001
-```
+Some features (chat assistant, AI-assisted finding interpretation, policy
+generation) require an Anthropic API key. ComplianceOS uses a Bring-Your-Own-Key
+model: your key, your account, your audit trail. Without a key the platform
+remains fully functional — the AI-assisted features simply stay disabled.
 
 ---
 
-## Port ändern
+## What you can already see in this public repository
 
-### Docker
+Even without a deployed instance, this repository documents the product in
+detail:
 
-Bearbeiten Sie `docker-compose.yml`:
+- [Architecture overview](../architecture.md) — pipeline, domains, standards
+- [Bedienung](../bedienung/dashboard.md) — full operating manual with
+  **24 screenshots** across dashboard, audits, chat, findings, policies,
+  reports and setup
+- [Demo videos](../videos/audit-workflow.mp4) — short clips of audit
+  workflow, finding lifecycle, policy generation, drift detection and chat
+- [Sample audit report](../samples/sample-audit-report.html) — a synthetic
+  end-to-end report rendered in the actual export format
+- [Standards reference](../referenz/standards.md) — the nine compliance
+  frameworks we cover
 
-```yaml
-ports:
-  - "9000:8001"  # Externer Port : Interner Port
-```
-
-Dann neu starten:
-
-```bash
-docker compose up -d
-```
-
-### pip
-
-```bash
-python -m uvicorn app.main:app --host 0.0.0.0 --port 9000
-```
+This is enough material for a procurement or security review committee to
+assess fit before requesting an evaluation.
 
 ---
 
-## Aktualisieren
+## Frequently asked
 
-### Docker
+**Why no public download?**
+ComplianceOS encodes proprietary control mappings, scoring logic and audit
+heuristics. Distributing the binary publicly would expose the dependency
+fingerprint of the build and undermine the value proposition for commercial
+customers. The evaluation flow gives qualified evaluators full access on their
+own infrastructure without that exposure.
 
-```bash
-cd complianceos
-git pull
-docker compose pull
-docker compose up -d
-```
+**Can I see the source code?**
+The audit toolkit definitions (control matrix, schemas) are openly documented
+under [Architecture](../architecture.md). The runtime source code stays
+private.
 
-### pip
+**How long does an evaluation last?**
+Standard evaluation period is 30 days, extendable on request. Activation codes
+are tier-bound and time-bound; expiry triggers a graceful read-only mode rather
+than data loss.
 
-```bash
-cd complianceos
-git pull
-pip install -e ".[ai,docs]"
-```
-
-!!! tip "Datenbank-Migrationen"
-    Nach einem Update führt ComplianceOS automatisch Datenbank-Migrationen beim Start durch. Bestehende Daten bleiben erhalten.
-
----
-
-## Deinstallation
-
-### Container stoppen (Daten bleiben erhalten)
-
-```bash
-docker compose down
-```
-
-### Container UND Daten löschen
-
-```bash
-docker compose down -v
-```
-
-!!! danger "Datenverlust"
-    `docker compose down -v` löscht alle gespeicherten Daten unwiderruflich: Audit-Ergebnisse, Findings, Dokumente, Policies, Einstellungen und Chat-Verläufe. Erstellen Sie vorher ein Backup der `data/`-Verzeichnisses.
-
----
-
-## Fehlerbehebung
-
-### Container startet nicht
-
-```bash
-# Logs anzeigen
-docker compose logs -f complianceos
-
-# Container-Status pruefen
-docker compose ps
-```
-
-### Port bereits belegt
-
-```
-Error: address already in use :::8001
-```
-
-Ein anderer Dienst nutzt Port 8001. Ändern Sie den Port (siehe oben) oder stoppen Sie den anderen Dienst.
-
-### Datenbank-Fehler
-
-```bash
-# Datenbank-Zustand pruefen
-docker compose exec complianceos python -c "
-import sqlite3
-conn = sqlite3.connect('/app/data/complianceos.db')
-print('Tables:', [r[0] for r in conn.execute(\"SELECT name FROM sqlite_master WHERE type='table'\").fetchall()])
-"
-```
-
-### Kein Internetzugang für Claude AI
-
-ComplianceOS benötigt Internetzugang nur für die Claude API. Wenn kein Internet verfügbar ist, funktionieren alle Kernfunktionen weiterhin — nur Chat und KI-Bewertungen sind deaktiviert.
+**What happens to evaluation data afterwards?**
+The data lives entirely on your infrastructure. We never receive a copy. If you
+choose not to convert to a commercial license, simply stop the container — the
+data directory is yours to archive or delete.


### PR DESCRIPTION
## Summary
- Replace \`docs/schnellstart/installation.md\` Docker/pip install instructions with the actual EULA evaluation flow (Issue Request → private delivery → customer deploys on own infra)
- Replace Schnellstart tabs in \`docs/index.md\` with an Evaluation section pointing at the issue template
- Closes the only doc/reality gap left after the public-readiness sprint: the public repo no longer ships \`docker-compose.yml\` or cloneable source, so the old \`git clone … && docker compose up -d\` instructions led nowhere

## Why
An HR/eval reviewer or procurement committee landing on \`Schnellstart › Installation\` was previously pointed at commands that cannot succeed against this repo. The new wording matches the §3.2 public-readiness decision (proprietary EULA, no public binary, eval via issue template).

## Out of scope
Other minor occurrences of \`docker-compose.yml\` references (in \`erste-schritte.md\`, \`einstellungen.md\`, \`audits.md\`, \`faq.md\`, \`datenschutz.md\`) describe deployment-internal config inside the delivered container and remain accurate after evaluation onboarding — left untouched.

## Test plan
- [ ] mkdocs build passes (CI)
- [ ] gitleaks/dependabot stay green
- [ ] Visual: \`docs/index.md\` Evaluation section links to \`schnellstart/installation.md\` and the issue template
- [ ] Visual: \`docs/schnellstart/installation.md\` no longer references \`git clone\` / \`docker compose up\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)