### PR TITLE
ci(gitleaks): switch from licensed action to direct binary

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -19,6 +19,20 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: gitleaks/gitleaks-action@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install gitleaks
+        run: |
+          GITLEAKS_VERSION="8.21.2"
+          curl -sSL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+            | tar -xz -C /usr/local/bin gitleaks
+          gitleaks version
+
+      - name: Run gitleaks
+        run: |
+          gitleaks detect \
+            --source . \
+            --no-banner \
+            --redact \
+            --verbose \
+            --exit-code 1 \
+            $( [ -f .gitleaks.toml ] && echo "--config .gitleaks.toml" )


### PR DESCRIPTION
## Summary
- Replace \`gitleaks/gitleaks-action@v2\` with a direct download and invocation of the upstream gitleaks binary (v8.21.2)
- Same behaviour (fail-on-detect, runs on push/PR/cron), no license required

## Why
\`gitleaks/gitleaks-action@v2\` now requires a paid license for org-owned repositories — every PR currently fails with \`[silentspike] is an organization. License key is required\`. The official gitleaks binary itself remains MIT-licensed, so we just call it directly.

## Test plan
- [ ] gitleaks check goes from fail → pass on this PR
- [ ] Job logs show \`gitleaks version\` and a clean detect run
- [ ] No new findings in the existing repo content

🤖 Generated with [Claude Code](https://claude.com/claude-code)