### PR TITLE
docs(regulations): add 6 regulation-specific detail pages

### DIFF
--- a/docs/business/for-who.md
+++ b/docs/business/for-who.md
@@ -14,7 +14,7 @@ Kontrolle ueber ihren Audit-Datenfluss behalten.
 
 **Primaere Regulierungen:**
 
-- NIS2 (EU-Richtlinie 2022/2555)
+- NIS2 (EU-Richtlinie 2022/2555) — [Detailseite](regulations/nis2.md)
 - BSI KRITIS-Verordnung (KritisV)
 - BSI IT-Sicherheitsgesetz 2.0
 
@@ -38,7 +38,7 @@ Kontrolle ueber ihren Audit-Datenfluss behalten.
 
 **Primaere Regulierungen:**
 
-- B3S Krankenhaus (Branchenspezifischer Sicherheitsstandard)
+- B3S Krankenhaus (Branchenspezifischer Sicherheitsstandard) — [Detailseite](regulations/b3s-krankenhaus.md)
 - DSGVO (fuer Patientendaten)
 - KHZG-relevante IT-Sicherheits-Foerdertatbestaende
 - ISO 27001 / 27799 (Medizinische Informatik)
@@ -62,10 +62,10 @@ Kontrolle ueber ihren Audit-Datenfluss behalten.
 
 **Primaere Regulierungen:**
 
-- **BAIT** (Bankaufsichtliche Anforderungen an die IT, BaFin)
-- **VAIT** (Versicherungsaufsichtliche Anforderungen an die IT)
-- **ZAIT** (Zahlungsdiensteaufsichtliche Anforderungen)
-- **DORA** (EU 2022/2554, Digital Operational Resilience Act)
+- **BAIT** (Bankaufsichtliche Anforderungen an die IT, BaFin) — [Detailseite](regulations/bait-vait-zait.md)
+- **VAIT** (Versicherungsaufsichtliche Anforderungen an die IT) — [Detailseite](regulations/bait-vait-zait.md)
+- **ZAIT** (Zahlungsdiensteaufsichtliche Anforderungen) — [Detailseite](regulations/bait-vait-zait.md)
+- **DORA** (EU 2022/2554, Digital Operational Resilience Act) — [Detailseite](regulations/dora.md)
 - PCI DSS (Karten-Akzeptanz)
 
 **Typische Anforderungen:**
@@ -87,7 +87,7 @@ Kontrolle ueber ihren Audit-Datenfluss behalten.
 
 **Primaere Regulierungen:**
 
-- **BSI IT-Grundschutz** (Kompendium 2023)
+- **BSI IT-Grundschutz** (Kompendium 2023) — [Detailseite](regulations/bsi-it-grundschutz.md)
 - BSI Mindeststandards fuer IT des Bundes
 - IT-Sicherheitsgesetz 2.0
 - Informationsfreiheitsgesetz-Implikationen
@@ -112,10 +112,10 @@ Kontrolle ueber ihren Audit-Datenfluss behalten.
 **Primaere Regulierungen:**
 
 - **ISO/IEC 27001** (internationale Zertifizierung)
-- **TISAX** (Automotive-Supply-Chain)
+- **TISAX** (Automotive-Supply-Chain) — [Detailseite](regulations/tisax.md)
 - DSGVO
 - Kunden-spezifische SLA-Anforderungen
-- Branchenspezifisch: NIS2 (wenn kritische Einrichtung)
+- Branchenspezifisch: NIS2 (wenn kritische Einrichtung) — [Detailseite](regulations/nis2.md)
 
 **Typische Anforderungen:**
 

--- a/docs/business/regulations/b3s-krankenhaus.md
+++ b/docs/business/regulations/b3s-krankenhaus.md
@@ -1,0 +1,90 @@
+# B3S Krankenhaus + KHZG
+
+> **Kontext:** Der branchenspezifische Sicherheitsstandard B3S Krankenhaus
+> ist von der Deutschen Krankenhausgesellschaft (DKG) erarbeitet und vom
+> BSI anerkannt. Er konkretisiert die KRITIS-Anforderungen fuer
+> Versorgungs-Krankenhaeuser ab 30.000 vollstationaeren Faellen pro Jahr.
+> Mit dem Krankenhauszukunftsgesetz (KHZG) wurde IT-Sicherheit zudem an
+> Foerdertatbestaende gekoppelt.
+
+---
+
+## Geltungsbereich
+
+- **B3S Krankenhaus**: Pflichtanwendung fuer KRITIS-Krankenhaeuser ab
+  30.000 vollstationaeren Faellen jaehrlich (KritisV).
+- **KHZG**: Foerderprogramm fuer Krankenhaeuser, mehrere Foerdertatbestaende
+  haben IT-Sicherheits-Bezug (insbesondere Foerdertatbestand 10 — IT-
+  Sicherheit, plus implizit Tatbestaende 1 / 5 mit IT-Schutzbedarf).
+- **DSGVO Art. 9** (besonders schuetzenswerte Daten — Gesundheitsdaten)
+  greift unabhaengig von der KRITIS-Schwelle.
+
+---
+
+## Pruefzyklus und Pruefer
+
+| Aspekt | Detail |
+|---|---|
+| Pruefzyklus | alle 2 Jahre |
+| Pruefende Stelle | nach BSI-Anforderungen anerkannte Pruefer |
+| Berichtsweg | Pruefbericht an BSI |
+| Sanktion bei Verstoessen | Bussgelder nach BSI-Gesetz, Reputations-Folgen |
+
+---
+
+## Schutzziele und Anforderungs-Bereiche
+
+Der B3S strukturiert Anforderungen entlang sechs Bereichen, die jeweils
+mit konkreten Massnahmen-Anforderungen hinterlegt sind:
+
+1. **Organisation der Informationssicherheit** — ISMS, Rollen, Verantwortlichkeiten
+2. **Personalsicherheit** — Schulung, Awareness, Geheimhaltung
+3. **Asset-Management** — Inventarisierung, Klassifizierung
+4. **Zugriffskontrolle** — RBAC, Notfall-Zugriff mit Audit-Trail
+5. **Kryptografie + Datentraegerverwaltung**
+6. **Physische Sicherheit + Betriebssicherheit** — inkl. Medizingeraete-
+   Netzsegmentierung
+
+Praxis-Schwerpunkte sind Notfall-Zugriff (Patientensicherheit ueber
+Datenschutz) und Medizingeraete-Vernetzung (IEC 80001-1).
+
+---
+
+## KHZG-Foerdertatbestaende mit IT-Sicherheits-Bezug
+
+| Tatbestand | Inhalt | IT-Sicherheits-Beruehrung |
+|---|---|---|
+| FT 1 | Notfallkapazitaeten + Krankenhaus-Alarm- und Einsatzplanung | indirekt: kritische Systeme verfuegbar halten |
+| FT 5 | Patienten-Portal | DSGVO-konforme Authentifizierung, Datenschutz |
+| FT 10 | IT-Sicherheit (Hardware/Software, Schwachstellenmanagement, Awareness) | direkt — Hauptfoerderlinie fuer ISMS-Aufbau |
+
+KHZG-Nachweise verlangen typischerweise eine Zuordnung der umgesetzten
+Massnahme zum jeweiligen Foerdertatbestand.
+
+---
+
+## ComplianceOS-Mapping
+
+ComplianceOS bildet B3S als eigene Standard-Auspraegung mit Cross-Mapping
+zu ISO 27001 und DSGVO ab. Praktisch hilfreich:
+
+- **Cross-Standard-Mapping** zeigt fuer jeden Control welche Standards
+  ihn referenzieren — eine Massnahme deckt B3S, ISO und DSGVO gleichzeitig
+- **Tagging-System** erlaubt Zuordnung zu KHZG-Foerdertatbestaenden, sodass
+  der gleiche Findings-Bestand nachweisseitig pro Tatbestand gefiltert
+  werden kann
+- **Audit-Trail** dokumentiert Notfall-Zugriffe und Aenderungen an
+  Zugriffsrechten
+- **Network-Segmentation-Domain** fuer Medizingeraete-Zonen
+- **PII-Domain (DSGVO Art. 9)** mit Betroffenen-Rechten-Checks
+
+---
+
+## Verweise
+
+- DKG B3S-Krankenhaus (BSI-anerkannt): [bsi.bund.de](https://www.bsi.bund.de/DE/Themen/KRITIS-und-regulierte-Unternehmen/B3S-und-Pruefverfahrenskompetenz/B3S/b3s_node.html)
+- KHZG (Krankenhauszukunftsgesetz): Bundesgesundheitsministerium
+- IEC 80001-1: Risikomanagement fuer IT-Netzwerke mit Medizingeraeten
+- DSGVO Art. 9: Verarbeitung besonderer Kategorien personenbezogener Daten
+
+ComplianceOS-Doku zum [Standards-Ueberblick](../../referenz/standards.md).

--- a/docs/business/regulations/bait-vait-zait.md
+++ b/docs/business/regulations/bait-vait-zait.md
@@ -1,0 +1,99 @@
+# BAIT / VAIT / ZAIT (BaFin)
+
+> **Kontext:** Die Bankaufsichtlichen Anforderungen an die IT (BAIT), die
+> Versicherungsaufsichtlichen Anforderungen an die IT (VAIT) und die
+> Zahlungsdiensteaufsichtlichen Anforderungen an die IT (ZAIT) sind drei
+> aufsichtliche Verlautbarungen der BaFin, die die regulatorischen
+> Erwartungen an die IT-Organisation finanzdienstleistender Unternehmen
+> konkretisieren. Sie sind eng verwandt — unterscheiden sich aber im
+> Geltungsbereich und in einzelnen sektoralen Spezifika.
+
+---
+
+## Abgrenzung der drei Rundschreiben
+
+| Verlautbarung | Adressaten | Aufsicht |
+|---|---|---|
+| **BAIT** | Kreditinstitute, Finanzdienstleistungsinstitute (KWG) | BaFin |
+| **VAIT** | Erst- und Rueckversicherungsunternehmen, Pensionskassen, Versicherungs-Holdings | BaFin |
+| **ZAIT** | Zahlungsinstitute, E-Geld-Institute (ZAG) | BaFin |
+
+Wer in mehreren Sektoren taetig ist (z.B. Bank mit Versicherungs-
+Tochter), erfuellt parallel die jeweils anwendbaren Vorgaben — hier zahlt
+sich Cross-Mapping aus.
+
+---
+
+## Gemeinsame Themenfelder
+
+Alle drei Verlautbarungen folgen demselben Aufbau und decken acht bis
+zehn Themenfelder ab, darunter:
+
+- IT-Strategie + IT-Governance
+- Informations-Risikomanagement (Schutzbedarfsfeststellung, Risikoanalyse)
+- Informationssicherheits-Management
+- Operativer Informationssicherheits-Betrieb (Vulnerability-Management,
+  Patch-Management)
+- Identitaets- und Rechte-Management (kritische Privilegien)
+- IT-Projekte + Anwendungsentwicklung (Change-Management)
+- IT-Betrieb (Datensicherung, Verfuegbarkeitsmanagement)
+- Auslagerungen + sonstige Fremdbezuege (eng mit DORA verzahnt)
+- Kritische Infrastrukturen (sektorenspezifisch)
+
+---
+
+## Pruefer und Pruefzyklen
+
+| Aspekt | Detail |
+|---|---|
+| Interne Revision | jaehrliches Pruefprogramm mit BAIT/VAIT/ZAIT-Schwerpunkten |
+| Externe Wirtschaftspruefer | jaehrliche Jahresabschlusspruefung mit IT-Pruefungs-Anteilen |
+| BaFin-Sonderpruefungen | nach Anlass (Vorfaelle, Hinweise, Schwerpunktpruefungen) |
+| Berichtsweg | Pruefberichte an Aufsichtsorgane + BaFin |
+
+---
+
+## Verzahnung mit DORA
+
+Mit Anwendung von **DORA** (EU 2022/2554, Anwendung ab 17. Januar 2025)
+werden zentrale Themen aus BAIT/VAIT/ZAIT auf EU-Ebene harmonisiert:
+
+- Auslagerungs- und Drittparteien-Management
+- Incident-Klassifikation und Meldung
+- Threat-Led-Penetration-Testing (TLPT)
+- ICT-Risikomanagement-Framework
+
+BAIT/VAIT/ZAIT bleiben fuer nationale Spezifika und Aufsichts-Erwartungen
+relevant; DORA setzt die EU-weite Mindestlinie. ComplianceOS modelliert
+beide Ebenen (siehe auch [DORA-Detailseite](dora.md)).
+
+---
+
+## ComplianceOS-Mapping
+
+| Themenfeld | ComplianceOS-Domain |
+|---|---|
+| Informations-Risikomanagement | RISK + CONFIG |
+| Informationssicherheits-Management | ACCESS + LOGGING |
+| Vulnerability + Patch-Management | VULN |
+| Identity + Access | ACCESS (12 Controls) |
+| Change-Management + Entwicklung | CONFIG |
+| Datensicherung + Verfuegbarkeit | BACKUP + BCP |
+| Auslagerungen + Drittparteien | SUPPLY |
+| Kryptografie | CRYPTO |
+| Incident-Klassifikation | INCIDENT |
+
+Standard-Plugins fuer BAIT, VAIT, ZAIT laden den jeweiligen Pflicht-Set
+und erzeugen aufsichtskonforme Reports — die Findings-Datenbank ist eine,
+die Pruefberichts-Sicht waehlbar.
+
+---
+
+## Verweise
+
+- BAFIN — Bankaufsichtliche Anforderungen an die IT (BAIT): [bafin.de](https://www.bafin.de/SharedDocs/Veroeffentlichungen/DE/Rundschreiben/2017/rs_1710_ba_BAIT.html)
+- BAFIN — Versicherungsaufsichtliche Anforderungen an die IT (VAIT)
+- BAFIN — Zahlungsdiensteaufsichtliche Anforderungen an die IT (ZAIT)
+- DORA: [eur-lex.europa.eu](https://eur-lex.europa.eu/eli/reg/2022/2554/oj)
+
+ComplianceOS-Doku zum [Standards-Ueberblick](../../referenz/standards.md).

--- a/docs/business/regulations/bsi-it-grundschutz.md
+++ b/docs/business/regulations/bsi-it-grundschutz.md
@@ -1,0 +1,113 @@
+# BSI IT-Grundschutz
+
+> **Kontext:** Der BSI IT-Grundschutz ist die in Deutschland etablierte
+> Methodik zur ganzheitlichen Informationssicherheit fuer den oeffentlichen
+> Sektor und Betreiber kritischer Infrastrukturen. Das aktuelle BSI
+> IT-Grundschutz-Kompendium 2023 enthaelt etwa 100 Bausteine in 10
+> Schichten und setzt auf Kombination mit ISO 27001 (Basis-Absicherung,
+> Standard-Absicherung, Kern-Absicherung).
+
+---
+
+## Methodik
+
+Der IT-Grundschutz folgt einer dreistufigen Vorgehensweise:
+
+1. **Strukturanalyse** — Ermittlung des Informationsverbunds (Systeme,
+   Anwendungen, Standorte, Personal, Geschaeftsprozesse)
+2. **Schutzbedarfsfeststellung** — Klassifikation der Werte in **normal**,
+   **hoch** und **sehr hoch** je Schutzziel (Vertraulichkeit, Integritaet,
+   Verfuegbarkeit)
+3. **Modellierung** — Zuordnung von Bausteinen aus dem Kompendium zu
+   den Komponenten des Informationsverbunds
+
+---
+
+## Drei Vorgehensweisen
+
+| Variante | Zielgruppe | Aufwand |
+|---|---|---|
+| **Basis-Absicherung** | KMU oder erste ISMS-Stufe | gering — verbindliche Basis-Anforderungen |
+| **Kern-Absicherung** | Fokus auf besonders kritische Werte | mittel — Konzentration auf Kronjuwelen |
+| **Standard-Absicherung** | Vollausbau, Ziel ISO-27001-Zertifizierung auf Basis IT-Grundschutz | hoch — vollstaendige Modellierung |
+
+Die Standard-Absicherung gilt als Vorlaeufer fuer eine ISO-27001-
+Zertifizierung auf Basis IT-Grundschutz, die in der oeffentlichen
+Verwaltung breit eingesetzt wird.
+
+---
+
+## Baustein-Schichten
+
+Das Kompendium organisiert Bausteine in zehn Schichten — jeweils mit
+prozessualer und technischer Auspraegung:
+
+| Schicht | Beispiel-Bausteine |
+|---|---|
+| ISMS | Sicherheitsmanagement |
+| ORP | Personal, Organisation |
+| CON | Kryptokonzept, Datensicherung |
+| OPS | Patch-Management, Schwachstellenmanagement |
+| DER | Detektion + Reaktion |
+| APP | Webanwendungen, Office-Produkte |
+| SYS | Allgemeiner Server, Windows-Client |
+| IND | ICS-Komponenten, ICS-Netze |
+| NET | Firewall, WLAN |
+| INF | Allgemeines Gebaeude, Rechenzentrum |
+
+Jeder Baustein definiert Basis-Anforderungen (verbindlich), Standard-
+Anforderungen und Anforderungen bei erhoehtem Schutzbedarf.
+
+---
+
+## Schutzbedarfs-Mapping
+
+Schutzbedarf wird kompakt in einer Schutzbedarfsfeststellung
+dokumentiert. Beispiel-Klassifikation:
+
+| Schutzziel | normal | hoch | sehr hoch |
+|---|---|---|---|
+| Vertraulichkeit | oeffentlich verfuegbare Daten | personenbezogene Daten | Staatsgeheimnisse, Patientendaten Art. 9 |
+| Integritaet | redaktionelle Drucksachen | Buchhaltungsdaten | Steuerungsdaten Notfallinfrastruktur |
+| Verfuegbarkeit | Toleranz Tage | Toleranz Stunden | Toleranz Minuten |
+
+Das Schutzbedarfs-Mapping vererbt sich entlang Abhaengigkeiten — eine
+Anwendung mit hohem Schutzbedarf zwingt typischerweise die unterliegende
+Datenbank in den gleichen Schutzbedarf.
+
+---
+
+## Pruefer und Nachweise
+
+| Aspekt | Detail |
+|---|---|
+| Pruefer | BSI-zertifizierte IT-Grundschutz-Auditoren |
+| Zertifizierung | ISO 27001 auf Basis IT-Grundschutz (Pruefverfahrenskompetenz beim BSI) |
+| Pruefzyklus | 3 Jahre Hauptaudit + jaehrliche Ueberwachungsaudits |
+| Nachweis | Referenzdokumente A.0 bis A.6 (Sicherheitskonzept, Realisierungsplan, etc.) |
+
+---
+
+## ComplianceOS-Mapping
+
+| Methodik-Schritt | ComplianceOS-Funktion |
+|---|---|
+| Strukturanalyse | Asset-Inventory mit Tagging fuer Bausteine |
+| Schutzbedarfsfeststellung | pro Asset konfigurierbar (CIA-Triade x normal/hoch/sehr hoch) |
+| Modellierung | Bausteine als Standard-Plugin, Zuordnung Asset → Bausteine |
+| Pruefung | Findings pro Anforderung mit Verbindlichkeitsstufe |
+| Reporting | BSI-Report-Format A.0–A.6, Drift-Detection zwischen Audits |
+
+Cross-Standard-Mapping zeigt die Kongruenz zwischen IT-Grundschutz-
+Bausteinen und ISO 27001 Annex A — was die Doppelfuehrung in
+Behoerden mit ISO + IT-Grundschutz vereinfacht.
+
+---
+
+## Verweise
+
+- BSI IT-Grundschutz-Kompendium 2023: [bsi.bund.de](https://www.bsi.bund.de/DE/Themen/Unternehmen-und-Organisationen/Standards-und-Zertifizierung/IT-Grundschutz/it-grundschutz_node.html)
+- BSI Mindeststandards fuer IT des Bundes
+- ISO/IEC 27001:2022
+
+ComplianceOS-Doku zum [Standards-Ueberblick](../../referenz/standards.md).

--- a/docs/business/regulations/dora.md
+++ b/docs/business/regulations/dora.md
@@ -1,0 +1,128 @@
+# DORA — Digital Operational Resilience Act
+
+> **Kontext:** Die EU-Verordnung 2022/2554 (DORA) ist seit dem 17. Januar
+> 2025 unmittelbar anwendbar. Sie etabliert eine harmonisierte Regelung
+> fuer digitale operationale Resilienz im Finanzsektor und greift in
+> nationale Anforderungen wie BAIT/VAIT/ZAIT mit hoeherem Vorrang ein.
+
+---
+
+## Geltungsbereich
+
+DORA gilt fuer **Finanzunternehmen** im Sinne von Art. 2 — darunter
+Kreditinstitute, Wertpapierfirmen, Zahlungsinstitute, E-Geld-Institute,
+Versicherungsunternehmen, zentrale Gegenparteien, Handelsplaetze und
+zentrale Verwahrer. Erfasst sind ebenfalls **kritische IKT-Drittdienst-
+leister** (z.B. grosse Cloud-Anbieter), die einer eigenen EU-Aufsicht
+unterliegen.
+
+Es gibt Erleichterungen fuer Kleinst-Unternehmen und definierte
+Schwellenwerte fuer einzelne Pflichten — die Grundpflichten zum
+ICT-Risikomanagement gelten jedoch grundsaetzlich.
+
+---
+
+## Fuenf Saeulen
+
+DORA strukturiert die Anforderungen entlang fuenf Themenbloecken:
+
+| Saeule | Inhalt |
+|---|---|
+| **1. ICT-Risikomanagement-Framework** | Governance, Strategie, Schutzbedarfsfeststellung, kontinuierliches Risiko-Monitoring (Art. 5–16) |
+| **2. Incident-Reporting** | Klassifikation, Meldepflichten, Eskalationsschwellen (Art. 17–23) |
+| **3. Resilience-Testing** | Regelmaessige Tests inkl. Threat-Led-Penetration-Testing (TLPT) fuer kritische Funktionen (Art. 24–27) |
+| **4. ICT-Drittparteien-Management** | Register, Vertragsanforderungen, Konzentrationsrisiken (Art. 28–44) |
+| **5. Informationsaustausch** | Branchenuebergreifende Threat-Intelligence-Plattformen (Art. 45) |
+
+---
+
+## Incident-Klassifikation (Art. 18)
+
+DORA verlangt eine konsistente Klassifikation von ICT-Vorfaellen anhand
+quantitativer und qualitativer Kriterien. Die Delegierte Verordnung der
+EU-Kommission (RTS) konkretisiert sieben Klassifikations-Kriterien:
+
+1. Anzahl und Bedeutung betroffener Kunden bzw. Gegenparteien
+2. Reputationsfolgen
+3. Dauer und Ausweitung des Vorfalls
+4. Geographische Reichweite
+5. Datenverlust (Vertraulichkeit, Integritaet, Verfuegbarkeit)
+6. Schwerwiegendheit des Auswirkens auf wirtschaftliche Funktionen
+7. Wirtschaftlicher Schaden
+
+Ein Vorfall gilt als **major** wenn definierte Schwellwerte ueber-
+schritten werden. Major-Vorfaelle sind nach DORA-Standardfristen zu
+melden.
+
+---
+
+## Threat-Led-Penetration-Testing (Art. 26-27)
+
+TLPT ist eine **Pflicht** fuer signifikante Finanzunternehmen. Es
+unterscheidet sich von gewoehnlichem Pen-Testing durch:
+
+- **Threat-Intelligence-basiertes Szenario** (TIBER-EU-Methodik)
+- **Live-Production-Testing** statt Test-Umgebung
+- **Akkreditierte Test-Provider** (TLPT-Authority pro Mitgliedstaat)
+- **Dreijaehrlicher Mindestturnus** mit Aufsichts-Beobachtung
+- **Vertrauliche Behandlung** der Befunde (begrenzter Adressatenkreis)
+
+In Deutschland ist die Bundesbank gemeinsam mit der BaFin die zustaendige
+TLPT-Authority.
+
+---
+
+## ICT-Drittparteien-Register (Art. 28)
+
+Finanzunternehmen muessen ein **Register aller ICT-Vertragsbeziehungen**
+fuehren mit Pflichtfeldern wie:
+
+- Identifikation des Dienstleisters (LEI)
+- Beschreibung des bezogenen Dienstes (kritisch / wichtig / sonstig)
+- Datenkategorien
+- Standorte der Datenverarbeitung
+- Sub-Outsourcing-Ketten
+
+Bei **kritischen ICT-Drittdienstleistern** (separat designiert auf EU-
+Ebene durch die ESAs) gelten erweiterte Vertragsanforderungen und
+Substitutions-Strategien.
+
+---
+
+## Meldefristen
+
+DORA harmonisiert die Frueh-Warnung und Folge-Meldungen. Die finalen
+Fristen ergeben sich aus den RTS / ITS:
+
+| Stufe | Frist |
+|---|---|
+| Initiale Meldung (major incident) | innerhalb weniger Stunden nach Klassifikation |
+| Zwischen-Meldung | innerhalb von 72 Stunden |
+| Abschluss-Bericht | binnen eines Monats nach Vorfalls-Behebung |
+
+In Deutschland: Meldung ueber das **Meldeportal der BaFin**.
+
+---
+
+## ComplianceOS-Mapping
+
+| DORA-Saeule | ComplianceOS-Domain | Hinweise |
+|---|---|---|
+| ICT-Risikomanagement | RISK + CONFIG | Schutzbedarfsfeststellung pro System |
+| Incident-Reporting | INCIDENT | Klassifikations-Logik mit konfigurierbaren Schwellen |
+| Resilience-Testing | BCP + VULN | TLPT-Vorbereitungs-Workflows |
+| Drittparteien-Management | SUPPLY | Tagging fuer Critical-ICT-Provider |
+| Informationsaustausch | LOGGING | strukturierte Threat-Intel-Importe |
+
+DORA-Plugin importiert die RTS-Definitionen, sodass Findings direkt
+nach DORA-Kriterien klassifiziert werden koennen.
+
+---
+
+## Verweise
+
+- EU 2022/2554 (DORA): [eur-lex.europa.eu](https://eur-lex.europa.eu/eli/reg/2022/2554/oj)
+- TIBER-EU Framework: ECB
+- BaFin DORA-Anwendungsleitfaden
+
+ComplianceOS-Doku zum [Standards-Ueberblick](../../referenz/standards.md).

--- a/docs/business/regulations/nis2.md
+++ b/docs/business/regulations/nis2.md
@@ -1,0 +1,102 @@
+# NIS2 (EU-Richtlinie 2022/2555)
+
+> **Kontext:** Die NIS2-Richtlinie ersetzt die NIS1-Richtlinie und erweitert
+> den Kreis der regulierten Einrichtungen. In Deutschland erfolgt die
+> Umsetzung ueber das KRITIS-Dachgesetz und die Aktualisierung des
+> BSI-Gesetzes.
+
+---
+
+## Geltungsbereich
+
+NIS2 unterscheidet zwischen **wesentlichen Einrichtungen** (Annex I) und
+**wichtigen Einrichtungen** (Annex II). Wesentliche Einrichtungen umfassen
+unter anderem Energie, Verkehr, Bankwesen, Finanzmarkt-Infrastruktur,
+Gesundheit, Trinkwasser, Abwasser, digitale Infrastruktur, IKT-
+Dienstemanagement, oeffentliche Verwaltung und Weltraum. Wichtige
+Einrichtungen umfassen unter anderem Post- und Kurierdienste,
+Abfallwirtschaft, Chemikalien, Lebensmittelproduktion, verarbeitendes
+Gewerbe und digitale Anbieter.
+
+In Deutschland kommen Schwellwerte aus dem **KRITIS-Dachgesetz** zur
+Anwendung — die Einstufung erfolgt branchenspezifisch ueber Versorgungs-
+und Umsatz-Kennzahlen.
+
+---
+
+## Pflichten nach Article 21 (Risikomanagement-Massnahmen)
+
+Article 21 NIS2 listet zehn Felder, fuer die alle regulierten Einrichtungen
+Massnahmen umsetzen muessen:
+
+1. Risikoanalyse- und Sicherheits-Konzepte fuer Informationssysteme
+2. Bewaeltigung von Sicherheitsvorfaellen
+3. Aufrechterhaltung des Betriebs (Backup-Management, Disaster Recovery,
+   Krisenmanagement)
+4. Sicherheit der Lieferkette
+5. Sicherheit beim Erwerb, der Entwicklung und der Wartung von Netz- und
+   Informationssystemen
+6. Konzepte und Verfahren zur Bewertung der Wirksamkeit der Risikomanagement-
+   Massnahmen
+7. Grundlegende Verfahren der Cyberhygiene und Schulung im Bereich Cyber-
+   sicherheit
+8. Konzepte und Verfahren fuer den Einsatz von Kryptografie und Verschluesselung
+9. Sicherheit des Personals, Konzepte fuer die Zugriffskontrolle und Asset-
+   Management
+10. Verwendung von Loesungen zur Multi-Faktor-Authentifizierung oder
+    kontinuierlicher Authentifizierung sowie gesicherten Kommunikations- und
+    Notfallkommunikationssystemen
+
+---
+
+## Meldepflichten (Article 23)
+
+Sicherheitsvorfaelle sind in drei Stufen zu melden:
+
+| Frist | Pflicht |
+|---|---|
+| **24 Stunden** | Frueh-Warnung an die zustaendige Behoerde (in Deutschland: BSI) — initiale Bewertung |
+| **72 Stunden** | Vollstaendige Vorfalls-Meldung mit detaillierter Bewertung |
+| **1 Monat** | Abschluss-Bericht mit Ursache und ergriffenen Massnahmen |
+
+Bei wesentlichen Einrichtungen kommen Pflichten zur Information der
+betroffenen Empfaenger und ggf. zur oeffentlichen Mitteilung hinzu.
+
+---
+
+## ComplianceOS-Mapping
+
+| NIS2-Pflicht (Art. 21) | ComplianceOS-Domain | Anzahl Controls |
+|---|---|---|
+| Risikoanalyse + Konzepte | RISK + CONFIG | 12 |
+| Bewaeltigung von Vorfaellen | INCIDENT | 8 |
+| Aufrechterhaltung des Betriebs | BCP + BACKUP | 18 |
+| Sicherheit der Lieferkette | SUPPLY | 6 |
+| Sichere Entwicklung + Wartung | CONFIG + VULN | 14 |
+| Bewertung der Wirksamkeit | LOGGING | 8 |
+| Cyberhygiene + Schulung | ACCESS + AWARENESS | 10 |
+| Kryptografie | CRYPTO | 11 |
+| Personal + Zugriffskontrolle | ACCESS + PII | 16 |
+| MFA + sichere Kommunikation | ACCESS + CRYPTO | 9 |
+
+Reports und Drift-Detection sind so konfigurierbar, dass sie die NIS2-
+Berichts-Struktur direkt abbilden.
+
+---
+
+## Zustaendige Behoerden
+
+In Deutschland: **BSI** (Bundesamt fuer Sicherheit in der Informationstechnik)
+ist die zustaendige Behoerde fuer NIS2-Meldungen. Branchenspezifische
+Aufsichtsbehoerden (z.B. **BNetzA** fuer Energie, **BaFin** fuer Finanz-
+sektor) bleiben fuer ihre jeweiligen Sektoren weiterhin zustaendig.
+
+---
+
+## Verweise
+
+- EU-Richtlinie 2022/2555 (NIS2): [eur-lex.europa.eu](https://eur-lex.europa.eu/eli/dir/2022/2555/oj)
+- KRITIS-Dachgesetz (Bundesgesetzblatt — Inkraftsetzung 2024-2025)
+- BSI Cybersicherheitsstrategie 2021
+
+ComplianceOS-Doku zum [Standards-Ueberblick](../../referenz/standards.md).

--- a/docs/business/regulations/tisax.md
+++ b/docs/business/regulations/tisax.md
@@ -1,0 +1,115 @@
+# TISAX (Trusted Information Security Assessment Exchange)
+
+> **Kontext:** TISAX ist die Audit-Norm der deutschen Automobilindustrie,
+> gepflegt durch die ENX Association. Sie basiert auf dem VDA ISA
+> (Information Security Assessment), einem Fragenkatalog zur Selbst-
+> beurteilung der Informationssicherheit. Pruefergebnisse sind ueber die
+> ENX-Plattform zwischen Mitgliedern austauschbar — das spart
+> Mehrfach-Audits derselben Lieferanten durch unterschiedliche OEMs.
+
+---
+
+## Pruefniveaus
+
+TISAX kennt drei Pruefniveaus, die sich nach Schutzbedarf und Audit-
+Tiefe unterscheiden:
+
+| Level | Audit-Tiefe | Typische Anwendung |
+|---|---|---|
+| **Level 1** | Self-Assessment ohne Pruefer-Beteiligung | interne Erstbewertung, niedriger Schutzbedarf |
+| **Level 2** | Self-Assessment + Plausibilitaets-Pruefung durch Pruefstelle (i.d.R. remote-basiert) | Standard-Lieferanten ohne hohen Verfuegbarkeits-/Geheimhaltungsbedarf |
+| **Level 3** | vollstaendiger Vor-Ort-Audit mit detaillierter Beweiserhebung | Lieferanten mit Zugang zu hochschutzbeduerftigen Informationen, Prototypen, Personenbezogene-Daten in grossem Umfang |
+
+Hoehere Level beinhalten alle Anforderungen der niedrigeren Level.
+
+---
+
+## VDA ISA Module
+
+Der zugrundeliegende VDA-ISA-Fragenkatalog ist modular aufgebaut. Welche
+Module zu erfuellen sind, haengt vom Schutzbedarf der bezogenen
+Informationen ab:
+
+| Modul | Inhalt | Verbindlich bei |
+|---|---|---|
+| **Information Security** | Basis-Informationssicherheit (ISO-27001-aehnlich) | jedem TISAX-Verfahren |
+| **Prototype Protection** | Schutz von Vorserien-Fahrzeugen, Bauteilen | OEMs + Tier-1 mit Prototypen-Zugang |
+| **Data Protection** | DSGVO Art. 28 Auftragsverarbeitung | bei Verarbeitung personenbezogener Daten |
+| **Connected Vehicle** (Pilot/Erweiterung) | Vernetzte Fahrzeug-Backend-Anbindung | bei Connected-Car-Lieferanten |
+
+Das Information-Security-Modul ist die Pflicht-Basis fuer **jedes**
+TISAX-Verfahren. Module wie Prototype-Protection oder Data-Protection
+werden je nach Lieferbeziehung hinzugewaehlt.
+
+---
+
+## Reife-Beurteilung
+
+Anforderungen werden in einer Reife-Skala 0–5 bewertet:
+
+| Reife | Bedeutung |
+|---|---|
+| 0 | nicht umgesetzt / nicht angemessen |
+| 1 | teilweise und ad-hoc umgesetzt |
+| 2 | ueberwiegend umgesetzt, dokumentiert |
+| 3 | vollstaendig umgesetzt + dokumentiert + ueberprueft |
+| 4 | proaktiv, kontinuierlich verbessert |
+| 5 | innovativ, branchenfuehrend |
+
+Die Soll-Reife ergibt sich pro Anforderung aus dem gewaehlten Pruefniveau.
+Reife 3 ist typischerweise das Mindestmass fuer Level 2 und Level 3.
+
+---
+
+## Pruefablauf Level 3 (vereinfacht)
+
+```text
+1. Scoping              — welche Standorte, Module, Schutzbedarf
+2. Self-Assessment      — Bewertung in der ENX-Plattform
+3. Pruefer-Auswahl      — ENX-akkreditierte Pruefstelle
+4. Pruef-Plan           — Vor-Ort-Termin-Vereinbarung
+5. Vor-Ort-Audit        — Beweiserhebung + Interviews
+6. Findings-Bearbeitung — Pruefer dokumentiert Reife-Bewertung
+7. Bericht + Label      — bei Erfolg: TISAX-Label fuer 3 Jahre
+8. ENX-Veroeffentlichung — Mitgliedern ueber Plattform zugaenglich
+```
+
+Bei groesseren Findings ist eine Nachpruefung erforderlich.
+
+---
+
+## OEM-spezifische Zusatzklauseln
+
+Einige OEMs ergaenzen das VDA-ISA-Basis-Set durch eigene Anforderungen
+(z.B. spezifische Verschluesselungs-Anforderungen, lokale Datenstandorte,
+besondere Reaktionszeiten bei Vorfaellen). Diese werden vertraglich
+zwischen OEM und Lieferant vereinbart und sind kein Teil des
+TISAX-Pruefumfangs — Lieferanten muessen sie aber zusaetzlich erfuellen.
+
+ComplianceOS unterstuetzt das ueber das Customer-Override-Pattern: Das
+TISAX-Basis-Set wird als generischer Standard geladen, OEM-spezifische
+Zusatz-Controls werden als Custom-Controls ergaenzt (siehe
+[Architektur-Doku](../../architecture.md)).
+
+---
+
+## ComplianceOS-Mapping
+
+| TISAX-Aspekt | ComplianceOS-Funktion |
+|---|---|
+| VDA-ISA Information Security | Standard-Plugin TISAX (mit Cross-Mapping zu ISO 27001) |
+| VDA-ISA Prototype Protection | Domain CONFIG + ACCESS mit Tagging "prototype" |
+| VDA-ISA Data Protection | Domain PII (DSGVO-Mapping) |
+| Reife-Beurteilung | Findings-Workflow mit Reife-0-bis-5 als Severity-Mapping |
+| OEM-Zusatzklauseln | Customer-Override (env-var COMPLIANCEOS_CONTROL_MATRIX) |
+| Drift zwischen Audits | Automatischer Drift-Report seit letztem Self-Assessment |
+
+---
+
+## Verweise
+
+- ENX Association: [enx.com/tisax](https://enx.com/en-us/tisax/)
+- VDA ISA Fragenkatalog (aktuelle Version): VDA QMC
+- ISO/IEC 27001:2022 (mappingrelevant)
+
+ComplianceOS-Doku zum [Standards-Ueberblick](../../referenz/standards.md).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -71,6 +71,13 @@ nav:
   - Fuer Entscheider:
     - Zielgruppen: business/for-who.md
     - ROI-Szenarien: business/roi.md
+    - Regulierungen:
+      - NIS2: business/regulations/nis2.md
+      - B3S Krankenhaus + KHZG: business/regulations/b3s-krankenhaus.md
+      - BAIT / VAIT / ZAIT: business/regulations/bait-vait-zait.md
+      - DORA: business/regulations/dora.md
+      - BSI IT-Grundschutz: business/regulations/bsi-it-grundschutz.md
+      - TISAX: business/regulations/tisax.md
   - Bedienung:
     - bedienung/dashboard.md
     - bedienung/audits.md


### PR DESCRIPTION
## Summary

Adds \`docs/business/regulations/\` with one detail page per regulation that appears across the for-who.md target audiences. Each page includes:

- Scope + applicability
- Pflicht-Felder (specific articles, audit cycles, reporting deadlines)
- ComplianceOS-Mapping table
- Public references

| Page | Topic |
|------|-------|
| nis2.md | Article 21 (10 fields), 24h/72h/1-month reporting, KRITIS-Dachgesetz scope |
| b3s-krankenhaus.md | B3S audit cycle, KHZG FT 1/5/10, DSGVO Art. 9 |
| bait-vait-zait.md | BAFin three sister regulations + DORA harmonisation |
| dora.md | 5 pillars, incident-classification RTS, TLPT, ICT third-party register |
| bsi-it-grundschutz.md | Methodology, Schutzbedarfsfeststellung, Bausteine |
| tisax.md | Levels 1/2/3, VDA-ISA modules, maturity 0-5, OEM add-ons |

\`for-who.md\` now links each regulation bullet to its detail page; \`mkdocs.yml\` gains a \"Regulierungen\" subsection under \"Fuer Entscheider\".

Closes #3.

## Test plan

- [ ] mkdocs build clean (CI)
- [ ] gitleaks pass
- [ ] Visual: 6 new files under docs/business/regulations/, 9 link refs in for-who.md, 6 nav entries in mkdocs.yml

🤖 Generated with [Claude Code](https://claude.com/claude-code)