### PR TITLE
docs(security): formalise responsible-disclosure channel + RFC 9116

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,39 +6,107 @@
 |---------|--------------------|
 | 1.0.x   | :white_check_mark: |
 
+---
+
 ## Reporting a Vulnerability
 
 **Please do NOT report security vulnerabilities through public GitHub issues.**
 
-Instead, please report them via [GitHub Security Advisories](https://github.com/silentspike/complianceos/security/advisories/new).
+We accept security reports through three channels (in order of preference):
 
-You can also reach us directly at: https://github.com/silentspike
+### 1. GitHub Security Advisories (recommended)
 
-### What to Include
+[Open a private advisory](https://github.com/silentspike/complianceos/security/advisories/new).
+Authenticated, confidential, and integrated with our triage workflow.
+
+### 2. Encrypted email
+
+> **Status (2026-04-26): channel-setup in progress.** The dedicated mailbox
+> and PGP key are being provisioned. Until the values below are populated,
+> please use Channel 1 (GitHub Security Advisories). This page will be
+> updated and the related tracking issue
+> ([#4](https://github.com/silentspike/complianceos/issues/4)) closed once
+> the channel is live.
+
+| Field | Value |
+|-------|-------|
+| Address | `<security@silentspike — pending>` |
+| PGP fingerprint | `<pending — to be published on keys.openpgp.org>` |
+| PGP key URL | `<pending>` |
+
+When the channel goes live the encrypted email path will be RFC-9116
+discoverable via [`/.well-known/security.txt`](docs/.well-known/security.txt).
+
+### 3. security.txt
+
+Machine-readable contact information per RFC 9116 lives at
+[`docs/.well-known/security.txt`](docs/.well-known/security.txt). The same
+file is published at the canonical URL once the documentation site is live.
+
+---
+
+## What to Include
 
 - Description of the vulnerability
-- Steps to reproduce
-- Potential impact assessment
-- Suggested fix (if any)
+- Affected component / version
+- Steps to reproduce (proof-of-concept code is welcome)
+- Potential impact assessment (CVSS v3.1 vector if available)
+- Suggested fix or mitigation (if any)
+- Whether you wish to be credited publicly or remain anonymous
 
-### Response Timeline
+---
+
+## Response SLAs
 
 | Stage | Target |
 |-------|--------|
-| Acknowledgment | 24 hours |
-| Triage & Assessment | 7 days |
-| Fix (Critical/High) | 30 days |
-| Fix (Medium/Low) | 90 days |
+| **Acknowledgment** of receipt | 24 hours |
+| **Initial triage + severity classification** | 72 hours |
+| **Fix or mitigation (Critical / High)** | 30 days |
+| **Fix or mitigation (Medium)** | 60 days |
+| **Fix or mitigation (Low)** | 90 days |
+| **Public disclosure (coordinated)** | typically 90 days after report |
 
-### Disclosure Policy
+We may request extensions on the disclosure timeline for complex issues
+that require coordination with downstream vendors. Such requests will be
+explained transparently and only when strictly necessary.
 
-We follow a 90-day coordinated disclosure policy. We ask that you:
+---
 
-1. Report the vulnerability privately using the method above
+## Disclosure Policy
+
+We follow a coordinated disclosure model:
+
+1. Report the vulnerability privately via one of the channels above
 2. Allow us reasonable time to address the issue before public disclosure
-3. Avoid exploiting the vulnerability beyond what is necessary to demonstrate it
+3. Avoid exploiting the vulnerability beyond what is necessary to
+   demonstrate impact
+4. Do not access, modify, or delete data that is not your own
 
-We will credit reporters in our changelog (unless anonymity is requested).
+We commit to:
+
+- Acknowledging receipt within the SLA above
+- Keeping the reporter informed of progress at meaningful milestones
+- Crediting reporters in our changelog and the published advisory (unless
+  anonymity is requested)
+- Not pursuing legal action against good-faith security researchers who
+  follow this policy
+
+---
+
+## Out of Scope
+
+The following are typically out of scope for this disclosure programme
+(but high-quality reports may still be acknowledged):
+
+- Findings against third-party services we use (please report to those
+  vendors directly)
+- Issues requiring physical access to a deployed customer instance
+- Issues requiring fully privileged access on the host operating system
+- Denial-of-service via resource exhaustion at the host level
+- Reports without a working proof-of-concept against a current release
+
+---
 
 ## Security Design
 
@@ -46,7 +114,10 @@ ComplianceOS is designed as an **on-premise application**:
 
 - All data is stored locally in SQLite
 - No telemetry or data collection
-- Optional AI features (Claude) are opt-in via `[ai]` install extra
-- No external network calls except optional AI queries
-- All user input is parameterized (SQL injection prevention)
-- File uploads are validated and sanitized
+- Optional AI features (Anthropic Claude, BYOK) are opt-in
+- No outbound network calls except optional AI queries (when configured)
+- Database access uses parameterised queries (SQL injection prevention)
+- File uploads are validated, type-checked, and sandboxed
+
+The internal threat model and hardening notes for licensed customers are
+delivered as part of the evaluation package.

--- a/docs/.well-known/security.txt
+++ b/docs/.well-known/security.txt
@@ -1,0 +1,14 @@
+# RFC 9116 — security.txt for silentspike / ComplianceOS
+#
+# Status (2026-04-26): channel-setup in progress.
+# The encrypted email and PGP key fields will be filled in once provisioned.
+# Until then, please use the GitHub Security Advisories channel listed below.
+# Tracking issue: https://github.com/silentspike/complianceos/issues/4
+
+Contact: https://github.com/silentspike/complianceos/security/advisories/new
+# Contact: mailto:security@silentspike.example  # pending — see issue #4
+Expires: 2027-04-26T00:00:00Z
+Preferred-Languages: en, de
+Canonical: https://silentspike.github.io/complianceos/.well-known/security.txt
+Policy: https://github.com/silentspike/complianceos/blob/main/SECURITY.md
+# Encryption: https://keys.openpgp.org/vks/v1/by-fingerprint/<pending>


### PR DESCRIPTION
## Summary

Partial implementation of #4 — covers the **documentation** layer of the responsible-disclosure setup. The mailbox + PGP-key provisioning itself remains a user-action and is **not** part of this PR.

### Changes

- **SECURITY.md** restructured with three explicit channels (GitHub Security Advisories, encrypted email, security.txt), expanded SLAs (72h triage, 30d/60d/90d for Critical/Medium/Low), explicit disclosure policy + out-of-scope section
- **docs/.well-known/security.txt** added per RFC 9116 with all five required fields (Contact, Expires, Preferred-Languages, Canonical, Policy) plus commented-out placeholders for the pending email/PGP fields

### Status note

The email (\`security@…\`) and PGP fingerprint are deliberate \`<pending>\` placeholders. Once the user has:
1. registered the mailbox / DNS MX,
2. generated the PGP key and published it on keys.openpgp.org,
3. filled the values into SECURITY.md + security.txt,

the tracking issue #4 can be closed. This PR keeps the issue **open**.

## Test plan

- [ ] mkdocs build clean (CI)
- [ ] gitleaks pass
- [ ] Visual: SECURITY.md has 3-channel structure + SLA table; security.txt has all RFC 9116 fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)