### PR TITLE
docs: drop dangling links to removed schnellstart/docker.md

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -137,10 +137,9 @@ Für eine detaillierte technische Erklärung der Audit-Engine und Bewertungsmeth
 
 | Seite | Beschreibung |
 |-------|-------------|
-| [Installation](schnellstart/installation.md) | Voraussetzungen, pip- und Docker-Installation |
+| [Installation](schnellstart/installation.md) | EULA-Eval-Flow, Voraussetzungen, On-Premise-Deployment |
 | [Claude-Setup](schnellstart/setup.md) | OAuth-Authentifizierung mit Claude AI |
 | [Erste Schritte](schnellstart/erste-schritte.md) | Projekt anlegen, ersten Audit durchführen |
-| [Docker](schnellstart/docker.md) | Docker Compose Konfiguration und Betrieb |
 | [Datenschutz](schnellstart/datenschutz.md) | Welche Daten wohin fliessen, lokale Verarbeitung |
 
 ### Bedienung

--- a/docs/referenz/faq.md
+++ b/docs/referenz/faq.md
@@ -81,7 +81,7 @@ docker run --rm \
   busybox tar czf /backup/complianceos-backup-$(date +%Y%m%d).tar.gz /data
 ```
 
-Details: [Docker-Konfiguration](../schnellstart/docker.md)
+Backup-Hinweise und Container-Konfiguration sind Teil der Eval-Lieferung. Siehe [Installation](../schnellstart/installation.md).
 
 ### Kann ich den Port ändern?
 
@@ -237,4 +237,4 @@ Die Standard-Beschreibungen und AUDIT-CHECKs sind in **Deutsch** hinterlegt. Eng
 
 ### Kann ich ComplianceOS im Internet erreichbar machen?
 
-ComplianceOS ist für den internen Einsatz konzipiert. Wenn Sie es extern erreichbar machen müssen, verwenden Sie einen **Reverse Proxy mit Authentifizierung** (z.B. nginx + Basic Auth oder SSO). Details: [Docker-Konfiguration](../schnellstart/docker.md)
+ComplianceOS ist für den internen Einsatz konzipiert. Wenn Sie es extern erreichbar machen müssen, verwenden Sie einen **Reverse Proxy mit Authentifizierung** (z.B. nginx + Basic Auth oder SSO). Konkrete Reverse-Proxy-Konfiguration ist Teil der Eval-Lieferung; siehe [Installation](../schnellstart/installation.md).


### PR DESCRIPTION
## Summary

Sprint v1.0.1 removed `docs/schnellstart/docker.md` (and the public `docker-compose.yml` itself) but three references survived: one row in the `docs/index.md` sitemap and two links in `docs/referenz/faq.md`. `mkdocs build --strict` (run as part of the follow-up sprint Plan-Verifikation) flagged all three. Replaced with redirects to the installation page (which already documents the EULA-evaluation flow).

Found by Plan-Verifikation, fixed immediately per /start-rule.

## Test plan

- [ ] mkdocs build --strict passes (CI + locally)
- [ ] gitleaks pass
- [ ] No semantic change beyond pointing readers at installation.md
