### PR TITLE
chore(security): GitHub Security Advisories as sole channel, remove email surface

### DIFF
--- a/.github/ISSUE_TEMPLATE/evaluation_request.yml
+++ b/.github/ISSUE_TEMPLATE/evaluation_request.yml
@@ -100,15 +100,6 @@ body:
       required: true
 
   - type: input
-    id: contact_email
-    attributes:
-      label: Kontakt-Email
-      description: Dienstliche Email-Adresse fuer die Evaluation-Korrespondenz
-      placeholder: "vorname.nachname@organisation.de"
-    validations:
-      required: true
-
-  - type: input
     id: contact_role
     attributes:
       label: Ihre Rolle

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,38 +10,19 @@
 
 ## Reporting a Vulnerability
 
-**Please do NOT report security vulnerabilities through public GitHub issues.**
+**Please do NOT report security vulnerabilities through public GitHub
+issues.**
 
-We accept security reports through three channels (in order of preference):
+ComplianceOS uses **GitHub Security Advisories** as the single channel
+for responsible disclosure. Advisories are private, authenticated, and
+integrated with our triage workflow — we do not operate a separate
+mailbox or PGP key.
 
-### 1. GitHub Security Advisories (recommended)
+[Open a private advisory](https://github.com/silentspike/complianceos/security/advisories/new)
 
-[Open a private advisory](https://github.com/silentspike/complianceos/security/advisories/new).
-Authenticated, confidential, and integrated with our triage workflow.
-
-### 2. Encrypted email
-
-> **Status (2026-04-26): channel-setup in progress.** The dedicated mailbox
-> and PGP key are being provisioned. Until the values below are populated,
-> please use Channel 1 (GitHub Security Advisories). This page will be
-> updated and the related tracking issue
-> ([#4](https://github.com/silentspike/complianceos/issues/4)) closed once
-> the channel is live.
-
-| Field | Value |
-|-------|-------|
-| Address | `<security@silentspike — pending>` |
-| PGP fingerprint | `<pending — to be published on keys.openpgp.org>` |
-| PGP key URL | `<pending>` |
-
-When the channel goes live the encrypted email path will be RFC-9116
-discoverable via [`/.well-known/security.txt`](docs/.well-known/security.txt).
-
-### 3. security.txt
-
-Machine-readable contact information per RFC 9116 lives at
-[`docs/.well-known/security.txt`](docs/.well-known/security.txt). The same
-file is published at the canonical URL once the documentation site is live.
+A machine-readable contact record per RFC 9116 lives at
+[`docs/.well-known/security.txt`](docs/.well-known/security.txt). It
+points at the same advisory URL as above.
 
 ---
 
@@ -77,8 +58,9 @@ explained transparently and only when strictly necessary.
 
 We follow a coordinated disclosure model:
 
-1. Report the vulnerability privately via one of the channels above
-2. Allow us reasonable time to address the issue before public disclosure
+1. Report the vulnerability privately via the advisory channel above
+2. Allow us reasonable time to address the issue before public
+   disclosure
 3. Avoid exploiting the vulnerability beyond what is necessary to
    demonstrate impact
 4. Do not access, modify, or delete data that is not your own
@@ -87,7 +69,7 @@ We commit to:
 
 - Acknowledging receipt within the SLA above
 - Keeping the reporter informed of progress at meaningful milestones
-- Crediting reporters in our changelog and the published advisory (unless
+- Crediting reporters in the published advisory and changelog (unless
   anonymity is requested)
 - Not pursuing legal action against good-faith security researchers who
   follow this policy

--- a/docs/.well-known/security.txt
+++ b/docs/.well-known/security.txt
@@ -1,14 +1,12 @@
 # RFC 9116 — security.txt for silentspike / ComplianceOS
 #
-# Status (2026-04-26): channel-setup in progress.
-# The encrypted email and PGP key fields will be filled in once provisioned.
-# Until then, please use the GitHub Security Advisories channel listed below.
-# Tracking issue: https://github.com/silentspike/complianceos/issues/4
+# We do not operate a separate security mailbox. All vulnerability reports
+# go through GitHub Security Advisories (private, authenticated, integrated
+# with our triage workflow). See SECURITY.md for the full disclosure
+# policy and SLAs.
 
 Contact: https://github.com/silentspike/complianceos/security/advisories/new
-# Contact: mailto:security@silentspike.example  # pending — see issue #4
 Expires: 2027-04-26T00:00:00Z
 Preferred-Languages: en, de
 Canonical: https://silentspike.github.io/complianceos/.well-known/security.txt
 Policy: https://github.com/silentspike/complianceos/blob/main/SECURITY.md
-# Encryption: https://keys.openpgp.org/vks/v1/by-fingerprint/<pending>


### PR DESCRIPTION
## Summary

Decision: **GitHub Security Advisories is the single responsible-disclosure channel.** No separate `security@` mailbox, no PGP key, no public email anywhere in the repo.

### Changes

- **SECURITY.md** — 3-channel structure replaced with single GitHub Security Advisory channel. PGP / encrypted-email sections removed. SLA table + disclosure policy + out-of-scope retained.
- **docs/.well-known/security.txt** — trimmed to RFC 9116 minimum (Contact = advisory URL, Expires, Preferred-Languages, Canonical, Policy). No email or PGP placeholder fields.
- **.github/ISSUE_TEMPLATE/evaluation_request.yml** — `contact_email` field removed; communication happens inside the GitHub issue thread, consistent with the no-email-channel decision.

### Why

Email-based responsible disclosure is legacy. GitHub Security Advisories provide the same private, authenticated reporting capability without the operational overhead of a mailbox + PGP key, and without exposing any address publicly.

Closes #4 (was: setup security@ mailbox — now wontfix per this decision).

## Test plan

- [ ] gitleaks pass
- [ ] mkdocs build clean
- [ ] `grep -rE '\S+@\S+\.\w+' --include='*.md' --include='*.txt' --include='*.yml' --include='*.yaml' --include='*.toml' --include='*.py'` returns 0 hits (excluding the Anthropic Co-Author trailer in commit messages, which lives in git history not files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
