### PR TITLE
chore(release): document v1.0.1 + v1.0.2 in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,71 @@ All notable changes to ComplianceOS will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.2] - 2026-04-26
+
+### Added
+- 3 additional ROI scenarios in `docs/business/roi.md`: Krankenhaus
+  (B3S + DSGVO + KHZG), Finanzdienstleister Mittelstand
+  (BAIT/VAIT/ZAIT + DORA), Automotive-Zulieferer (TISAX Level 2/3) —
+  now 6 illustrative scenarios total
+- 6 regulation-specific detail pages under `docs/business/regulations/`:
+  NIS2, B3S Krankenhaus, BAIT/VAIT/ZAIT, DORA, BSI IT-Grundschutz,
+  TISAX. Linked from `for-who.md`, navigable via mkdocs sidebar
+- `docs/architecture/control-matrix-workflow.md`: explicit description
+  of the three-tier SSOT topology (toolkit canonical → public-binary
+  embed → customer-override via `COMPLIANCEOS_CONTROL_MATRIX` env-var)
+  with embed pattern, customer-override walkthrough, sync process,
+  extending-base-set example
+- `docs/.well-known/security.txt` per RFC 9116 (Contact, Expires,
+  Preferred-Languages, Canonical, Policy)
+
+### Changed
+- Installation guide rewritten to reflect the EULA evaluation flow:
+  no `git clone` / `docker compose up`, instead the issue-template
+  request-and-private-delivery flow (matches the §3.2 sprint decision
+  in v1.0.1)
+- `SECURITY.md` consolidated to a single GitHub-Security-Advisory
+  channel — no separate security mailbox, no PGP key, no public email
+  surface anywhere in the repo. SLAs explicitly listed (24h ack /
+  72h triage / 30d critical / 60d medium / 90d low)
+- Evaluation request issue template no longer asks for an email
+  address; communication happens inside the GitHub issue thread
+
+### Fixed
+- Three dangling links to the removed `schnellstart/docker.md` page
+  (in `docs/index.md` sitemap and `docs/referenz/faq.md`) — found by
+  `mkdocs build --strict`
+
+### CI / Tooling
+- `gitleaks` workflow switched from the licensed `gitleaks-action@v2`
+  to a direct invocation of the upstream binary (no license required
+  for org-owned repositories)
+
+## [1.0.1] - 2026-04-26
+
+### Added
+- Architecture deep-dive page `docs/architecture.md` (pipeline,
+  domains, standards)
+- Target-audience and ROI documentation:
+  `docs/business/for-who.md`, `docs/business/roi.md`
+- Synthetic end-to-end sample audit report:
+  `docs/samples/sample-audit-report.html`
+- `evaluation_request.yml` issue template with EULA acknowledgement
+- `gitleaks` + `dependabot` workflows; org-profile published
+
+### Changed
+- Public repo restructured for evaluation-focused enterprise
+  discovery (proprietary EULA, no public binary downloads)
+- `LICENSE` consolidated to proprietary across public marketing repo
+  and source repo
+- Embedded `assets/control-matrix.yaml` sanitised — homelab-specific
+  IPs and M365 container references replaced with placeholders;
+  toolkit-generic template shipped as default
+
+### Removed
+- `docker-compose.yml` and `docs/schnellstart/docker.md` — the
+  evaluation flow no longer assumes self-service container start
+
 ## [1.0.0] - 2026-02-24
 
 ### Added


### PR DESCRIPTION
Adds v1.0.1 and v1.0.2 entries to CHANGELOG.md (public-readiness sprint + follow-up sprint). Tag v1.0.2 will be set after merge.

Closes the previous CHANGELOG gap (jumped from v1.0.0 to nothing, while v1.0.1 was tagged).
