### PR TITLE
ci(docs): run mkdocs --strict on PRs as a merge gate

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,6 +6,13 @@ on:
     paths:
       - 'docs/**'
       - 'mkdocs.yml'
+      - '.github/workflows/docs.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - '.github/workflows/docs.yml'
 
 permissions:
   contents: read
@@ -13,7 +20,7 @@ permissions:
   id-token: write
 
 concurrency:
-  group: "pages"
+  group: "pages-${{ github.ref }}"
   cancel-in-progress: true
 
 jobs:
@@ -29,15 +36,17 @@ jobs:
       - name: Install dependencies
         run: pip install mkdocs>=1.6 mkdocs-material>=9.5 mkdocs-glightbox>=0.4
 
-      - name: Build docs
-        run: mkdocs build
+      - name: Build docs (strict — fail on broken links / nav warnings)
+        run: mkdocs build --strict
 
       - uses: actions/upload-pages-artifact@v5
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         with:
           path: site
 
   deploy:
     needs: build
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     environment:
       name: github-pages


### PR DESCRIPTION
Adds pull_request trigger to the Docs workflow and switches build to `mkdocs build --strict`. Upload + deploy stay push-to-main-only.

Catches broken links / nav issues at PR-time (like the F-001 finding from the previous sprint) instead of after merge.
