### PR TITLE
docs: consolidate AUDIT-CHECKs count to 2.285 + add Gap-Analyse section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,7 +74,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - 9 compliance standards: ISO 27001, ISO 22301, ISO 27005, ISO 27017, ISO 27018, ISO 27035, NIS2, BSI IT-Grundschutz, DSGVO
-- 135 audit controls across 12 domains with 2,246 semantic AUDIT-CHECKs
+- 135 audit controls across 12 domains with 2,285 semantic AUDIT-CHECKs
 - Chat-first interface with Claude AI integration for compliance guidance
 - Automated audit engine with parallel check execution
 - Intent classification system (9 intents) with built-in responses

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ ComplianceOS richtet sich an IT-Sicherheitsbeauftragte, Compliance-Manager und C
 
 ### Kernfunktionen
 
-- **Audit-Engine** — 135 Controls in 12 Domains mit 2.246 semantischen Pruefpunkten, automatische und manuelle Checks
+- **Audit-Engine** — 135 Controls in 12 Domains mit 2.285 semantischen Pruefpunkten, automatische und manuelle Checks
 - **KI-Chat** — Compliance-Fragen stellen, Findings analysieren, Empfehlungen erhalten (Claude AI, optional)
 - **Findings-Management** — Severity-Klassifikation, Status-Workflow, Zuweisung, Deadlines
 - **Remediation-Tracking** — Massnahmen verfolgen, Verantwortliche zuweisen, Fortschritt messen

--- a/docs/bedienung/audits.md
+++ b/docs/bedienung/audits.md
@@ -266,7 +266,7 @@ Die Knowledge Base ist das Fundament aller Audits. Sie enthält das gesamte norm
 |----------|--------|-------------|
 | **Standards** | 9 | ISO 27001, ISO 22301, ISO 27005, ISO 27017, ISO 27018, ISO 27035, NIS2, BSI IT-Grundschutz, DSGVO |
 | **Controls** | 135 | Technische Prüfpunkte, gruppiert in 12 Sicherheitsdomains |
-| **AUDIT-CHECKs** | 2.042 | Atomare Prüfanweisungen pro Control — die konkreten Fragen die ein Auditor stellen würde |
+| **AUDIT-CHECKs** | 2.285 | Atomare Prüfanweisungen pro Control — die konkreten Fragen die ein Auditor stellen würde |
 | **Domains** | 12 | Sicherheitsbereiche (ACCESS, BACKUP, BCP, CONFIG, CRYPTO, INCIDENT, LOGGING, MALWARE, NETWORK, PII, SUPPLY, VULN) |
 
 Die Knowledge Base wird beim Start des Servers geladen und ist vollständig lokal gespeichert. Sie benötigt keinen Internetzugang.
@@ -428,7 +428,7 @@ ComplianceOS prüft gegen folgende Standards:
 
 ### 135 Controls, 12 Domains
 
-Jeder Control gehört zu genau einer Domain und wird durch mehrere AUDIT-CHECKs geprüft. Insgesamt gibt es 2.042 AUDIT-CHECKs — die atomaren Prüfpunkte die bei jedem Audit durchlaufen werden.
+Jeder Control gehört zu genau einer Domain und wird durch mehrere AUDIT-CHECKs geprüft. Insgesamt gibt es 2.285 AUDIT-CHECKs — die atomaren Prüfpunkte die bei jedem Audit durchlaufen werden.
 
 ### Verifikationsmethoden
 

--- a/docs/bedienung/chat.md
+++ b/docs/bedienung/chat.md
@@ -25,7 +25,7 @@ Der Chat-Assistent hat Zugriff auf:
 - Ihre aktuellen Audit-Ergebnisse und Findings
 - Alle 9 unterstützten Standards und deren Anforderungen
 - Ihre Projekt-Einstellungen und aktiven Standards
-- Die Knowledge-Base mit 135 Controls und 2.042 AUDIT-CHECKs
+- Die Knowledge-Base mit 135 Controls und 2.285 AUDIT-CHECKs
 
 ---
 

--- a/docs/bedienung/dashboard.md
+++ b/docs/bedienung/dashboard.md
@@ -86,7 +86,7 @@ Zeigt vier Kennzahlen der integrierten Wissensbasis:
 |----------|-------------|
 | **Standards** | Anzahl der unterstützten Standards (9) |
 | **Controls** | Technische Prüfpunkte (135) |
-| **AUDIT-CHECKs** | Semantische Anforderungen (2.042) |
+| **AUDIT-CHECKs** | Semantische Anforderungen (2.285) |
 | **Domains** | Sicherheitsbereiche (12) |
 
 ---

--- a/docs/bedienung/dokumente.md
+++ b/docs/bedienung/dokumente.md
@@ -93,6 +93,25 @@ Der vollständige extrahierte Textinhalt wird angezeigt. Bei PDF- und Word-Dokum
 
 ---
 
+## Gap-Analyse
+
+ComplianceOS analysiert hochgeladene Dokumente automatisch auf Luecken gegenueber den 135 Controls. Die Gap-Analyse nutzt kuratierte Keywords (`doc_keywords`) aus der Control-Matrix sowie extrahierte Begriffe aus Control-Namen und -Beschreibungen.
+
+### Ergebnis
+
+| Feld | Beschreibung |
+|------|-------------|
+| **Abgedeckte Controls** | Controls deren Keywords im Dokument gefunden wurden |
+| **Luecken** | Controls deren Keywords im Dokument fehlen |
+| **Abdeckungsquote** | Prozentualer Anteil der abgedeckten Controls |
+
+Die Analyse laeuft pro Dokument und als Aggregation ueber alle Dokumente eines Projekts. So erkennen Sie auf einen Blick, welche Compliance-Themen durch Ihre bestehende Dokumentation abgedeckt sind und wo Handlungsbedarf besteht.
+
+!!! tip "Gap-Analyse optimieren"
+    Je vollstaendiger Ihre Dokumente sind, desto aussagekraeftiger ist die Gap-Analyse. Laden Sie alle relevanten Policies, Betriebshandbuecher und Konfigurationsdokumente hoch.
+
+---
+
 ## Dokument löschen
 
 1. Öffnen Sie das Dokument in der Detailansicht

--- a/docs/bedienung/einstellungen.md
+++ b/docs/bedienung/einstellungen.md
@@ -168,7 +168,7 @@ Zeigt technische Informationen über die ComplianceOS-Installation:
 | **Datenbankgrösse** | Aktuelle Grösse der SQLite-Datenbank |
 | **Standards** | Anzahl der geladenen Standards (9) |
 | **Controls** | Anzahl technischer Prüfpunkte (135) |
-| **AUDIT-CHECKs** | Anzahl semantischer Anforderungen (2.042) |
+| **AUDIT-CHECKs** | Anzahl semantischer Anforderungen (2.285) |
 | **Domains** | Anzahl Sicherheitsbereiche (12) |
 
 ---

--- a/docs/index.md
+++ b/docs/index.md
@@ -198,7 +198,8 @@ Für eine detaillierte technische Erklärung der Audit-Engine und Bewertungsmeth
 | **Standards** | 9 (ISO 27001, 22301, 27005, 27017, 27018, 27035, NIS2, BSI, DSGVO) |
 | **Controls** | 135 technische Prüfpunkte |
 | **Domains** | 12 Sicherheitsbereiche |
-| **AUDIT-CHECKs** | 2.042 semantische Anforderungen |
+| **AUDIT-CHECKs** | 2.285 semantische Anforderungen |
+| **Sprachen** | Deutsch, Englisch (per-Request, umschaltbar) |
 | **Deployment** | Docker Compose oder pip install |
 | **Datenbank** | SQLite (WAL-Modus, lokal) |
 | **Lizenz** | Proprietary (EULA) |

--- a/docs/referenz/faq.md
+++ b/docs/referenz/faq.md
@@ -129,7 +129,7 @@ Der Confidence-Wert (0-100%) zeigt wie zuverlässig die automatische Bewertung e
 
 Der Audit läuft im Hintergrund weiter, auch wenn Sie den Browser-Tab schliessen. Die Ergebnisse finden Sie anschliessend im Audit-Verlauf.
 
-### Woher kommen die 2.042 AUDIT-CHECKs?
+### Woher kommen die 2.285 AUDIT-CHECKs?
 
 Die AUDIT-CHECKs sind das Ergebnis einer systematischen Analyse aller 9 Standards. Jeder Artikel, jede Klausel und jeder Baustein wurde in atomare, technisch prüfbare Anforderungen zerlegt. Beispiel: Ein einzelner ISO-Control wie "Kryptografie" (A.8.24) wird in 5-15 konkrete Prüffragen aufgelöst (TLS-Version, Algorithmen, Schlüsselmanagement etc.).
 

--- a/docs/referenz/glossar.md
+++ b/docs/referenz/glossar.md
@@ -13,7 +13,7 @@ Dieses Glossar erklärt die wichtigsten Begriffe die in ComplianceOS und der Com
 : Systematische, unabhängige Prüfung gegen definierte Anforderungen (Standards, Richtlinien, Controls). ComplianceOS unterscheidet Vollaudits (alle 135 Controls) und Domain-Audits (eine Domain).
 
 **AUDIT-CHECK**
-: Atomarer Prüfpunkt innerhalb eines Controls. Jeder Control besteht aus mehreren AUDIT-CHECKs die bei der Prüfung einzeln bewertet werden. ComplianceOS enthält 2.042 AUDIT-CHECKs.
+: Atomarer Prüfpunkt innerhalb eines Controls. Jeder Control besteht aus mehreren AUDIT-CHECKs die bei der Prüfung einzeln bewertet werden. ComplianceOS enthält 2.285 AUDIT-CHECKs.
 
 ## B
 

--- a/docs/referenz/standards.md
+++ b/docs/referenz/standards.md
@@ -18,7 +18,7 @@ ComplianceOS unterstützt 9 internationale Sicherheits- und Compliance-Standards
 | BSI IT-Grundschutz | 2023 | Framework | IT-Sicherheit (DACH-spezifisch) | 16 |
 | DSGVO | 2016/679 | EU-Verordnung | Datenschutz | 10 |
 
-**Gesamt:** 135 Controls, verteilt auf 12 Sicherheitsdomains, geprüft durch 2.042 AUDIT-CHECKs.
+**Gesamt:** 135 Controls, verteilt auf 12 Sicherheitsdomains, geprüft durch 2.285 AUDIT-CHECKs.
 
 ---
 


### PR DESCRIPTION
Three different counts were drifting across the public surface (2.046 / 2.246 / 2.285). Consolidates to 2.285 across README, CHANGELOG, index.md, and 7 docs pages.

Also adds a Gap-Analyse section to docs/bedienung/dokumente.md and a Sprachen row to docs/index.md technical-eckdaten table.