### PR TITLE
docs(readme): audit-polish — split-note, datenfluss-diagram, english summary

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,12 +6,14 @@ on:
     paths:
       - 'docs/**'
       - 'mkdocs.yml'
+      - 'README.md'
       - '.github/workflows/docs.yml'
   pull_request:
     branches: [main]
     paths:
       - 'docs/**'
       - 'mkdocs.yml'
+      - 'README.md'
       - '.github/workflows/docs.yml'
 
 permissions:

--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@
 > Die Ergebnisse dienen als Entscheidungsgrundlage und muessen von qualifizierten
 > Fachpersonen geprueft werden.
 
+> **Hinweis zum Repository:** Dieses oeffentliche Repository enthaelt die
+> Dokumentation und Evaluation-Surface. Anwendungs-Source und ausfuehrbare
+> Binaries werden privat unter EULA bereitgestellt. Siehe
+> [Evaluation anfordern](#evaluation-anfordern) fuer den Ablauf.
+
 ---
 
 ## Was ist ComplianceOS?
@@ -50,6 +55,26 @@ ComplianceOS richtet sich an IT-Sicherheitsbeauftragte, Compliance-Manager und C
 - **Executive Dashboard** — Risiko-Matrix, Business Impact, Compliance-Trends
 - **Dokument-Pipeline** — PDF, DOCX, XLSX, Markdown hochladen und analysieren
 - **Multi-Projekt** — Mehrere Organisationen/Projekte parallel verwalten
+
+### Datenfluss
+
+```mermaid
+flowchart LR
+    User[User<br/>Browser/CLI]
+    App[ComplianceOS<br/>FastAPI + HTMX]
+    DB[(SQLite<br/>local)]
+    Docs[Local Docs<br/>PDF/DOCX/MD]
+    Claude[Claude API<br/>optional]
+
+    User --> App
+    App --> DB
+    App --> Docs
+    App -.optional.-> Claude
+```
+
+Macht den No-Telemetry / On-Prem / Optional-AI-Charakter sofort sichtbar:
+nur ein einziger optionaler Out-Pfad (gestrichelt) verlaesst die Kunden-
+Infrastruktur, alles andere bleibt lokal.
 
 ### Design
 
@@ -131,3 +156,14 @@ sind diese Seiten der schnellste Einstieg:
 ComplianceOS ist proprietaere Software. Siehe [LICENSE](LICENSE) fuer Details.
 
 Copyright (c) 2026 ComplianceOS / silentspike. Alle Rechte vorbehalten.
+
+## In English
+
+ComplianceOS is an on-premise compliance audit platform for regulated sectors
+(KRITIS, healthcare, finance, public administration, regulated SMB). It runs
+entirely on customer infrastructure with optional Claude AI support, no
+telemetry, and SQLite/local document storage. Evaluation flow: private
+delivery under EULA, 90-day pilot, security committee review.
+
+- Documentation: https://silentspike.github.io/complianceos/
+- Evaluation request: https://github.com/silentspike/complianceos/issues/new?template=evaluation_request.yml


### PR DESCRIPTION
## Summary

Drei README-Polishes aus externem Audit-Prompt 2026-04-27:

1. **Public/Private-Split-Note** — Hinweis-Block unter Disclaimer adressiert Reviewer-Frage "Where is the code?" und referenziert die Evaluation-Anfrage-Section per Anker.
2. **Mermaid-Datenfluss-Diagramm** — vor `### Design` eingefuegt; macht den No-Telemetry / On-Prem / Optional-AI-Charakter direkt im README sichtbar (gestrichelter optionaler Pfad zu Claude API). Mermaid ist via `pymdownx.superfences` auch in mkdocs gerendert.
3. **"In English" Section** — am Ende; kurze englische Zusammenfassung mit vollstaendigen Direktlinks (Documentation + Evaluation-Request) fuer internationale Reader.

## Out of scope (bewusst nicht in diesem PR)

- Item 7 (Dependabot Security-Updates) bereits separat per `gh api PATCH` aktiviert
- Items 1, 2, 6 bereits in vorhergehenden PRs gefixt (PR #23 + Branch-Protection)

## Test plan

- [x] `grep "Hinweis zum Repository" README.md` zeigt Split-Note in Zeile 17
- [x] `grep "^## In English" README.md` zeigt Section in Zeile 160
- [x] `grep "^### Datenfluss\\|^\`\`\`mermaid" README.md` zeigt Diagramm in Zeile 59/61
- [x] AUDIT-CHECKs-Drift unveraendert (kein 2.042/2.246-Treffer in README)
- [ ] CI: build, gitleaks, CodeQL, Analyze (actions), Analyze (python) — alle 5 Required Status Checks