### PR TITLE
docs(readme): reposition disclosure note + datenfluss diagram (v2 stage 1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,6 @@
 > Die Ergebnisse dienen als Entscheidungsgrundlage und muessen von qualifizierten
 > Fachpersonen geprueft werden.
 
-> **Hinweis zum Repository:** Dieses oeffentliche Repository enthaelt die
-> Dokumentation und Evaluation-Surface. Anwendungs-Source und ausfuehrbare
-> Binaries werden privat unter EULA bereitgestellt. Siehe
-> [Evaluation anfordern](#evaluation-anfordern) fuer den Ablauf.
-
 ---
 
 ## Was ist ComplianceOS?
@@ -26,6 +21,31 @@
 ComplianceOS ist eine On-Premise-Plattform fuer automatisierte Compliance-Audits gegen internationale Sicherheitsstandards. Die Anwendung laeuft vollstaendig auf Ihrer eigenen Infrastruktur — keine Daten verlassen Ihr Netzwerk. Eine optionale KI-Integration (Claude) unterstuetzt bei der Analyse und Beratung.
 
 ComplianceOS richtet sich an IT-Sicherheitsbeauftragte, Compliance-Manager und CISOs, die ihre Audit-Prozesse strukturieren und automatisieren moechten.
+
+> ⚠ **Hinweis zum Repository:** Dieses oeffentliche Repository enthaelt die
+> Dokumentation und Evaluation-Surface. Anwendungs-Source und ausfuehrbare
+> Binaries werden privat unter EULA bereitgestellt. Siehe
+> [Evaluation anfordern](#evaluation-anfordern).
+
+## Datenfluss
+
+```mermaid
+flowchart LR
+    User[User<br/>Browser/CLI]
+    App[ComplianceOS<br/>FastAPI + HTMX]
+    DB[(SQLite<br/>local)]
+    Docs[Local Docs<br/>PDF/DOCX/MD]
+    Claude[Claude API<br/>optional]
+
+    User --> App
+    App --> DB
+    App --> Docs
+    App -.optional.-> Claude
+```
+
+Macht den No-Telemetry / On-Prem / Optional-AI-Charakter sofort sichtbar:
+nur ein einziger optionaler Out-Pfad (gestrichelt) verlaesst die Kunden-
+Infrastruktur, alles andere bleibt lokal.
 
 ## Features
 
@@ -55,26 +75,6 @@ ComplianceOS richtet sich an IT-Sicherheitsbeauftragte, Compliance-Manager und C
 - **Executive Dashboard** — Risiko-Matrix, Business Impact, Compliance-Trends
 - **Dokument-Pipeline** — PDF, DOCX, XLSX, Markdown hochladen und analysieren
 - **Multi-Projekt** — Mehrere Organisationen/Projekte parallel verwalten
-
-### Datenfluss
-
-```mermaid
-flowchart LR
-    User[User<br/>Browser/CLI]
-    App[ComplianceOS<br/>FastAPI + HTMX]
-    DB[(SQLite<br/>local)]
-    Docs[Local Docs<br/>PDF/DOCX/MD]
-    Claude[Claude API<br/>optional]
-
-    User --> App
-    App --> DB
-    App --> Docs
-    App -.optional.-> Claude
-```
-
-Macht den No-Telemetry / On-Prem / Optional-AI-Charakter sofort sichtbar:
-nur ein einziger optionaler Out-Pfad (gestrichelt) verlaesst die Kunden-
-Infrastruktur, alles andere bleibt lokal.
 
 ### Design
 


### PR DESCRIPTION
## Summary

v2-Sprint Stage 1 — Quick Wins:

1. **Public/Private-Note an Hero-Ende verschoben** — vorher direkt nach Badges (zu frueh), jetzt nach `## Was ist ComplianceOS?` mit Warnsymbol fuer Sichtbarkeit. Reviewer liest erst Hero-Pitch, dann Disclosure.
2. **Datenfluss-Diagramm prominenter** — vorher H3-Sub-Section unter Features, jetzt eigene H2-Section direkt vor Features. 30s-Skim erfasst die On-Prem/Optional-AI-Architektur sofort.
3. **Reihenfolge:** Hero → Public-Note → Datenfluss → Features.

## Changes

- README.md: 25 insertions, 25 deletions (pure repositioning, kein Inhaltswandel)

## Test plan

- [x] `grep -nE "^## Was ist|Hinweis zum Repository|^## Datenfluss|^## Features" README.md` zeigt korrekte Reihenfolge: 19/25/30/50
- [x] Anker `#datenfluss` bleibt durch H2 `## Datenfluss` (GitHub-Auto-Anker)
- [ ] CI: build, gitleaks, CodeQL, Analyze (actions), Analyze (python) — alle 5 Required Status Checks