### PR TITLE
docs: v2 stage 2 — english summary, license clarity, ai-deployment doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,15 @@ Thank you for your interest in ComplianceOS!
 
 ## Code Contributions
 
-ComplianceOS is proprietary software. We do not accept external code contributions at this time.
+ComplianceOS is proprietary software. We do not accept external code contributions to the application source.
+
+The public repository (documentation, examples, ROI templates) accepts contributions in the following areas:
+
+- **Documentation accuracy** — bug reports for incorrect or outdated documentation
+- **Regulatory standards coverage** — suggestions for additional standards or controls
+- **Translation/localization improvements** — DE/EN parity, terminology accuracy
+
+Please use the [Bug Report](https://github.com/silentspike/complianceos/issues/new?template=bug_report.yml) or [Feature Request](https://github.com/silentspike/complianceos/issues/new?template=feature_request.yml) templates. Application source and executable binaries are delivered privately under EULA — see [LICENSE](LICENSE).
 
 ## Feedback
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,12 @@
 ComplianceOS - Proprietary Software License
 
+NOTICE — Public Repository Scope:
+This public repository contains documentation and evaluation assets only.
+Application source code and executable binaries are licensed separately
+under the ComplianceOS End User License Agreement (EULA), available upon
+evaluation request via the GitHub Issue template
+(.github/ISSUE_TEMPLATE/evaluation_request.yml).
+
 Copyright (c) 2026 ComplianceOS / silentspike. All rights reserved.
 
 TERMS AND CONDITIONS

--- a/README.md
+++ b/README.md
@@ -121,6 +121,9 @@ ComplianceOS ist eine **On-Premise-Anwendung**:
 
 Die KI-Integration ist vollstaendig optional und kann durch Weglassen der Umgebungsvariable `ENABLE_TEAMMATES=false` deaktiviert werden.
 
+Hintergrund zum Deployment-Modell und der On-Prem-AI-Boundary: siehe
+[AI Deployment in regulierten Umgebungen](docs/business/ai-deployment-relevance.md).
+
 ## Dokumentation
 
 Die vollstaendige Bedienungsanleitung finden Sie unter:

--- a/README.md
+++ b/README.md
@@ -157,13 +157,33 @@ ComplianceOS ist proprietaere Software. Siehe [LICENSE](LICENSE) fuer Details.
 
 Copyright (c) 2026 ComplianceOS / silentspike. Alle Rechte vorbehalten.
 
-## In English
+## English Summary
 
-ComplianceOS is an on-premise compliance audit platform for regulated sectors
-(KRITIS, healthcare, finance, public administration, regulated SMB). It runs
-entirely on customer infrastructure with optional Claude AI support, no
-telemetry, and SQLite/local document storage. Evaluation flow: private
-delivery under EULA, 90-day pilot, security committee review.
+### Hero
+
+ComplianceOS is an on-premise compliance audit platform for regulated organizations and the public sector. It runs entirely on customer infrastructure with optional Claude AI support, no telemetry, and SQLite/local document storage.
+
+### What it is
+
+Automates audits against international security standards: ISO/IEC 27001:2022, ISO 22301, ISO/IEC 27005, ISO/IEC 27017/27018, ISO/IEC 27035, NIS2, BSI IT-Grundschutz, GDPR. Coverage: 9 standards, 135 controls in 12 domains, 2,285 semantic checkpoints.
+
+### Audience
+
+Built for KRITIS operators (energy, water, telecom under NIS2/KritisV), hospitals (B3S-Krankenhaus, GDPR), financial services (BAIT/VAIT/ZAIT, DORA), public administration (BSI IT-Grundschutz), and regulated mid-sized enterprises (200-5000 employees) with ISO 27001 / TISAX requirements.
+
+### Architecture
+
+See the [Mermaid data flow diagram](#datenfluss) above and the [Architecture Overview](docs/architecture.md). Stack: Python (FastAPI + HTMX + SQLite), with optional Claude API integration that can be disabled via environment variable (`ENABLE_TEAMMATES=false`).
+
+### Evaluation flow
+
+Private delivery under EULA. 90-day pilot on customer infrastructure. Compliance artifacts documented for the first audit cycle. Request via the [evaluation_request.yml](https://github.com/silentspike/complianceos/issues/new?template=evaluation_request.yml) issue template.
+
+### Public/Private disclosure
+
+This public repository contains documentation and evaluation surface. Application source and executable binaries are delivered privately under EULA. The product is proprietary software. See [docs/business/ai-deployment-relevance.md](docs/business/ai-deployment-relevance.md) for AI deployment in regulated environments.
+
+### Resources
 
 - Documentation: https://silentspike.github.io/complianceos/
 - Evaluation request: https://github.com/silentspike/complianceos/issues/new?template=evaluation_request.yml

--- a/docs/business/ai-deployment-relevance.md
+++ b/docs/business/ai-deployment-relevance.md
@@ -1,0 +1,64 @@
+# AI Deployment in Regulated Environments
+
+Compliance-Audits sind sensibles Terrain fuer KI-Integration. Daten duerfen
+nicht in die Cloud, Audit-Trails muessen nachvollziehbar bleiben, regulatorische
+Anforderungen (DSGVO Art. 25, BSI C5, NIS2 Art. 21) verlangen klare technische
+und organisatorische Massnahmen. ComplianceOS ist gegen genau dieses
+Spannungsfeld designed.
+
+## On-Prem AI Boundary
+
+Compliance-Daten verlassen die Kunden-Infrastruktur nicht.
+
+- Optional Claude API integration: nur Audit-Pruefpunkte und Findings-Analysen
+  werden gesendet
+- Dokumente, Reports und Datenbank bleiben lokal
+- Konkretisierung: SQLite lokal, Document-Pipeline laeuft auf der
+  Kunden-Infrastruktur, kein outbound traffic im default Setup
+
+## Optional AI Integration (Privacy-First)
+
+KI-Integration ist abschaltbar.
+
+- `ENABLE_TEAMMATES=false` deaktiviert die KI-Integration komplett
+- Kein Telemetrie, kein Tracking
+- Disclosure transparent dokumentiert in der README-Datenschutz-Section
+
+## No-Telemetry
+
+Keine externe Datenuebertragung.
+
+- SQLite lokal — keine externe Datenbank
+- Audit-Trail bleibt im Customer-Hosting
+- Logging ueber lokale Pipelines (Loki/Grafana wenn vorhanden, sonst Filesystem)
+
+## Regulated Evaluation Flow
+
+Pilot-Modell ist auf regulierte Branchen zugeschnitten.
+
+- 90-Tage-Pilot auf der Kunden-Infrastruktur
+- Vollstaendige Audit-Artefakte fuer den ersten Compliance-Zyklus (Asset-Inventar,
+  Risk-Register, Policy-Set, Remediation-Plan)
+- Klar dokumentierte Reifegrade: ISMS-Aufbau, Asset-Management, Risk-Treatment
+
+## Pilot Model
+
+EULA-basiert, persoenliche Begleitung.
+
+- EULA-basiertes Lizenzmodell (siehe [Evaluation anfordern](https://github.com/silentspike/complianceos/issues/new?template=evaluation_request.yml))
+- Begleitung durch silentspike (fachlich + regulatorisch)
+- Skalierbar nach Pilot — Lizenz-Renewal pro Audit-Zyklus oder per-Standard
+
+## Bottom Line
+
+Wenn Sie KI in einer regulierten Umgebung einsetzen wollen, ist die
+Architektur-Frage *zuerst* eine Boundary-Frage und *danach* eine Modell-Frage.
+ComplianceOS definiert die Boundary explizit und macht die optionale
+KI-Integration zu einem abschaltbaren Add-on, nicht zu einer Voraussetzung.
+
+## Verweise
+
+- [Architektur-Ueberblick](../architecture.md)
+- [Control-Matrix Workflow](../architecture/control-matrix-workflow.md)
+- [Datenschutz-Hinweise im README](https://github.com/silentspike/complianceos#datenschutz)
+- [Evaluation Request Template](https://github.com/silentspike/complianceos/issues/new?template=evaluation_request.yml)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -73,6 +73,7 @@ nav:
   - Fuer Entscheider:
     - Zielgruppen: business/for-who.md
     - ROI-Szenarien: business/roi.md
+    - AI Deployment in regulierten Umgebungen: business/ai-deployment-relevance.md
     - Regulierungen:
       - NIS2: business/regulations/nis2.md
       - B3S Krankenhaus + KHZG: business/regulations/b3s-krankenhaus.md


### PR DESCRIPTION
## Summary

v2-Sprint Stage 2 — Substanz. 4 atomare Commits:

1. **English Summary erweitern** — vorher 6-Zeilen-Bullet `## In English`, jetzt `## English Summary` mit 6 strukturierten Outcome-Sections (Hero / What it is / Audience / Architecture / Evaluation flow / Public/Private disclosure) plus Resources. Architecture-Section verlinkt das Mermaid-Diagramm `#datenfluss`.
2. **LICENSE Pre-Amble** — klarstellt dass der oeffentliche Repository nur Doku/Eval-Assets enthaelt, App-Source/Binaries laufen separat unter EULA via Issue-Template.
3. **CONTRIBUTING.md praezisieren** — Code-Contributions-Section: App-Source bleibt proprietaer, aber Doku-Accuracy / Standards-Vorschlaege / DE/EN-Translation sind willkommen.
4. **`docs/business/ai-deployment-relevance.md` neu** — Lead + 5 Sections (On-Prem AI Boundary, Optional AI Integration, No-Telemetry, Regulated Evaluation Flow, Pilot Model) + Bottom Line. Tool-agnostisch (kein Codex-spezifisch). mkdocs.yml nav-Eintrag unter "Fuer Entscheider". README Datenschutz-Section verlinkt die neue Doku.

## Test plan

- [x] `grep -nE "^### Hero|^### What it is|^### Audience|^### Architecture|^### Evaluation flow|^### Public/Private disclosure" README.md` → 6 Treffer
- [x] `head -10 LICENSE | grep -i "EULA\|public repository"` → Pre-Amble sichtbar
- [x] `grep -i "translation\|documentation accuracy" CONTRIBUTING.md` → 2 Treffer
- [x] `ls docs/business/ai-deployment-relevance.md` → existiert
- [x] `grep "ai-deployment-relevance" mkdocs.yml` → nav-Eintrag
- [x] mkdocs --strict lokal: clean (6.80s, keine Warnings)
- [ ] CI: build, gitleaks, CodeQL, Analyze (actions), Analyze (python) — alle 5 Required Status Checks